### PR TITLE
Replace unrecognized printf verb

### DIFF
--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -80,7 +80,7 @@ func TestNewError(t *testing.T) {
 
 func ExampleErrorf(x int) (int, error) {
 	if x%2 == 1 {
-		return 0, Errorf("can only halve even numbers, got %i", x)
+		return 0, Errorf("can only halve even numbers, got %d", x)
 	} else {
 		return x / 2, nil
 	}


### PR DESCRIPTION
I ran `go vet ./...` and it complained about `%i`.
