### PR TITLE
Added an option to override error class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,13 +228,13 @@ bugsnag.Notify(err,
 
 ### Error Class
 
-Errors in your Bugsnag dashboard are grouped by their "error class".
+Errors in your Bugsnag dashboard are grouped by their "error class" and by line number.
 You can override the error class by passing a
 [`bugsnag.ErrorClass`](https://godoc.org/github.com/bugsnag/bugsnag-go/#ErrorClass) object as
 rawData.
 
 ```go
-bugsnag.Notify(err, bugsnag.ErrorClass{Name: "I/O Timeout"})
+bugsnag.Notify(err, bugsnag.ErrorClass{"I/O Timeout"})
 ```
 
 ### Context

--- a/README.md
+++ b/README.md
@@ -226,6 +226,17 @@ bugsnag.Notify(err,
     bugsnag.User{Id: "1234", Name: "Conrad", Email: "me@cirw.in"})
 ```
 
+### Error Class
+
+Errors in your Bugsnag dashboard are grouped by their "error class".
+You can override the error class by passing a
+[`bugsnag.ErrorClass`](https://godoc.org/github.com/bugsnag/bugsnag-go/#ErrorClass) object as
+rawData.
+
+```go
+bugsnag.Notify(err, bugsnag.ErrorClass{Name: "I/O Timeout"})
+```
+
 ### Context
 
 The context shows up prominently in the list view so that you can get an idea

--- a/event.go
+++ b/event.go
@@ -21,6 +21,12 @@ type User struct {
 	Email string `json:"email,omitempty"`
 }
 
+// ErrorClass overrides the error class in Bugsnag.
+// This struct enables you to group errors as you like.
+type ErrorClass struct {
+	Name string
+}
+
 // Sets the severity of the error on Bugsnag. These values can be
 // passed to Notify, Recover or AutoNotify as rawData.
 var (
@@ -107,6 +113,9 @@ func newEvent(err *errors.Error, rawData []interface{}, notifier *Notifier) (*Ev
 
 		case User:
 			event.User = &datum
+
+		case ErrorClass:
+			event.ErrorClass = datum.Name
 		}
 	}
 


### PR DESCRIPTION
I guess this pull request solves https://github.com/bugsnag/bugsnag-go/issues/17.
As ConradIrwin says, just using the error message is too unique. So I added an option to configure ErrorClass like [bugsnag-node's errorName](https://github.com/bugsnag/bugsnag-node#errorname).