### PR TITLE
Don't swallow errors in a goroutine

### DIFF
--- a/notifier.go
+++ b/notifier.go
@@ -43,7 +43,8 @@ func (notifier *Notifier) Notify(err error, rawData ...interface{}) (e error) {
 			if config.Synchronous {
 				return (&payload{event, config}).deliver()
 			}
-			go (&payload{event, config}).deliver()
+			// Ensure that any errors are logged if they occur in a goroutine.
+			go (&payload{event, config}).deliverOrLog()
 			return nil
 		}
 		return fmt.Errorf("not notifying in %s", config.ReleaseStage)

--- a/notifier.go
+++ b/notifier.go
@@ -44,7 +44,13 @@ func (notifier *Notifier) Notify(err error, rawData ...interface{}) (e error) {
 				return (&payload{event, config}).deliver()
 			}
 			// Ensure that any errors are logged if they occur in a goroutine.
-			go (&payload{event, config}).deliverOrLog()
+			go func(event *Event, config *Configuration) {
+				err := (&payload{event, config}).deliver()
+				if err != nil {
+					config.log("bugsnag.Notify: %v", err)
+				}
+			}(event, config)
+
 			return nil
 		}
 		return fmt.Errorf("not notifying in %s", config.ReleaseStage)

--- a/payload.go
+++ b/payload.go
@@ -47,7 +47,7 @@ func (p *payload) deliver() error {
 func (p *payload) deliverOrLog() {
 	err := p.deliver()
 	if err != nil {
-		fmt.Println(err)
+		p.log("bugsnag.deliver: %v", err)
 	}
 }
 

--- a/payload.go
+++ b/payload.go
@@ -44,6 +44,13 @@ func (p *payload) deliver() error {
 	return nil
 }
 
+func (p *payload) deliverOrLog() {
+	err := p.deliver()
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
 func (p *payload) MarshalJSON() ([]byte, error) {
 
 	data := hash{

--- a/payload.go
+++ b/payload.go
@@ -44,13 +44,6 @@ func (p *payload) deliver() error {
 	return nil
 }
 
-func (p *payload) deliverOrLog() {
-	err := p.deliver()
-	if err != nil {
-		p.log("bugsnag.deliver: %v", err)
-	}
-}
-
 func (p *payload) MarshalJSON() ([]byte, error) {
 
 	data := hash{


### PR DESCRIPTION
The current implementation will swallow any delivery errors that run in a goroutine (the default behaviour). This PR changes the goroutine to call `deliverOrLog` which will at least log any errors which occur. We spent a fair amount of time debugging why errors were not being notified only to find that we didn't have any SSL Certificates in our Docker image, and bugsnag was unable to connect. Due to the lack of any error reporting, this was a bit of a rabbit-hole to figure out.

![swallow](http://i.imgur.com/XEmGzTv.gif) 