### PR TITLE
refactor tests for stripProjectPackages

### DIFF
--- a/configuration_test.go
+++ b/configuration_test.go
@@ -44,23 +44,76 @@ func TestNotifyReleaseStages(t *testing.T) {
 	}
 }
 
-func TestProjectPackages(t *testing.T) {
+func TestIsProjectPackage(t *testing.T) {
 
-	Configure(Configuration{ProjectPackages: []string{"main", "github.com/ConradIrwin/*"}})
+	Configure(Configuration{ProjectPackages: []string{
+		"main",
+		"star*",
+		"example.com/a",
+		"example.com/b/*",
+		"example.com/c/*/*",
+	}})
 
 	var testCases = []struct {
 		Path     string
 		Included bool
 	}{
+		{"", false},
 		{"main", true},
-		{"github.com/ConradIrwin/foo", true},
-		{"github.com/ConradIrwin/foo/bar", false},
 		{"runtime", false},
+
+		{"star", true},
+		{"sta", false},
+		{"starred", true},
+		{"star/foo", false},
+
+		{"example.com/a", true},
+
+		{"example.com/b", false},
+		{"example.com/b/", true},
+		{"example.com/b/foo", true},
+		{"example.com/b/foo/bar", false},
+
+		{"example.com/c/foo/bar", true},
+		{"example.com/c/foo/bar/baz", false},
 	}
 
 	for _, s := range testCases {
 		if Config.isProjectPackage(s.Path) != s.Included {
-			t.Error("literal project package doesn't work")
+			t.Error("literal project package doesn't work:", s.Path, s.Included)
+		}
+	}
+}
+
+func TestStripProjectPackage(t *testing.T) {
+
+	Configure(Configuration{ProjectPackages: []string{
+		"main",
+		"star*",
+		"example.com/a",
+		"example.com/b/*",
+		"example.com/c/*/*",
+	}})
+
+	var testCases = []struct {
+		File     string
+		Stripped string
+	}{
+		{"main.go", "main.go"},
+		{"runtime.go", "runtime.go"},
+		{"star.go", "star.go"},
+
+		{"example.com/a/foo.go", "foo.go"},
+
+		{"example.com/b/foo/bar.go", "foo/bar.go"},
+		{"example.com/b/foo.go", "foo.go"},
+
+		{"example.com/x/a/b/foo.go", "example.com/x/a/b/foo.go"},
+	}
+
+	for _, tc := range testCases {
+		if s := Config.stripProjectPackages(tc.File); s != tc.Stripped {
+			t.Error("stripProjectPackage did not remove expected path:", tc.File, tc.Stripped, "was:", s)
 		}
 	}
 }

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -45,20 +45,24 @@ func TestNotifyReleaseStages(t *testing.T) {
 }
 
 func TestProjectPackages(t *testing.T) {
+
 	Configure(Configuration{ProjectPackages: []string{"main", "github.com/ConradIrwin/*"}})
-	if !Config.isProjectPackage("main") {
-		t.Error("literal project package doesn't work")
-	}
-	if !Config.isProjectPackage("github.com/ConradIrwin/foo") {
-		t.Error("wildcard project package doesn't work")
-	}
-	if Config.isProjectPackage("runtime") {
-		t.Error("wrong packges being marked in project")
-	}
-	if Config.isProjectPackage("github.com/ConradIrwin/foo/bar") {
-		t.Error("wrong packges being marked in project")
+
+	var testCases = []struct {
+		Path     string
+		Included bool
+	}{
+		{"main", true},
+		{"github.com/ConradIrwin/foo", true},
+		{"github.com/ConradIrwin/foo/bar", false},
+		{"runtime", false},
 	}
 
+	for _, s := range testCases {
+		if Config.isProjectPackage(s.Path) != s.Included {
+			t.Error("literal project package doesn't work")
+		}
+	}
 }
 
 type LoggoWrapper struct {


### PR DESCRIPTION
This refactors the tests for `Config.ProjectPackages` to use an array of test cases.

I've added tests for ProjectPackages with multiple wildcards.

It does not change existing behaviour.