### PR TITLE
Lowercase request map

### DIFF
--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -214,8 +214,8 @@ func TestHandler(t *testing.T) {
 		"payloadVersion":          "2",
 		"severity":                "info",
 		"user.id":                 "127.0.0.1",
-		"metaData.Request.Url":    "http://" + l.Addr().String() + "/ok?foo=bar",
-		"metaData.Request.Method": "GET",
+		"metaData.request.url":    "http://" + l.Addr().String() + "/ok?foo=bar",
+		"metaData.request.method": "GET",
 	} {
 		key := strings.Split(k, ".")
 		if event.GetPath(key...).MustString() != value {
@@ -223,7 +223,7 @@ func TestHandler(t *testing.T) {
 		}
 	}
 
-	if event.GetPath("metaData", "Request", "Params", "foo").GetIndex(0).MustString() != "bar" {
+	if event.GetPath("metaData", "request", "params", "foo").GetIndex(0).MustString() != "bar" {
 		t.Errorf("missing GET params in request metadata")
 	}
 

--- a/middleware.go
+++ b/middleware.go
@@ -66,11 +66,11 @@ func httpRequestMiddleware(event *Event, config *Configuration) error {
 			}
 
 			event.MetaData.Update(MetaData{
-				"Request": {
-					"RemoteAddr": request.RemoteAddr,
-					"Method":     request.Method,
-					"Url":        proto + request.Host + request.RequestURI,
-					"Params":     request.URL.Query(),
+				"request": {
+					"remoteAddr": request.RemoteAddr,
+					"method":     request.Method,
+					"url":        proto + request.Host + request.RequestURI,
+					"params":     request.URL.Query(),
 				},
 			})
 


### PR DESCRIPTION
This changes the notifier to use a lowercase "request" and "url" in the metadata. This means that Bugsnag will allow filtering by URL for Go notifications.