### PR TITLE
Add ErrorWithCallers interface

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -19,6 +19,13 @@ type Error struct {
 	frames []StackFrame
 }
 
+// ErrorWithCallers allows passing in error objects that
+// also have caller information attached.
+type ErrorWithCallers interface {
+	Error() string
+	Callers() []uintptr
+}
+
 // New makes an Error from the given value. If that value is already an
 // error then it will be used directly, if not, it will be passed to
 // fmt.Errorf("%v"). The skip parameter indicates how far up the stack
@@ -29,6 +36,11 @@ func New(e interface{}, skip int) *Error {
 	switch e := e.(type) {
 	case *Error:
 		return e
+	case ErrorWithCallers:
+		return &Error{
+			Err:   e,
+			stack: e.Callers(),
+		}
 	case error:
 		err = e
 	default:
@@ -53,6 +65,11 @@ func Errorf(format string, a ...interface{}) *Error {
 // Error returns the underlying error's message.
 func (err *Error) Error() string {
 	return err.Err.Error()
+}
+
+// Callers returns the raw stack frames as returned by runtime.Callers()
+func (err *Error) Callers() []uintptr {
+	return err.stack[:]
 }
 
 // Stack returns the callstack formatted the same way that go does


### PR DESCRIPTION
This allows the creation of error objects other than bugsnag.Error that have stack-traces.

The use case for us is making errors that are Retryable and also have the right stack trace: https://github.com/codeship/go-retro

Now I have more experience with go, I'd probably have written this library to use an interface type rather than a struct type from the start; but this is a backward compatible addition.
