### PR TITLE
Support stack from go-errors/errors package

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"runtime"
+	GoErrors "github.com/go-errors/errors"
 )
 
 // The maximum number of stackframes on any error.
@@ -36,6 +37,17 @@ func New(e interface{}, skip int) *Error {
 	switch e := e.(type) {
 	case *Error:
 		return e
+	case *GoErrors.Error:
+		stackframes := e.StackFrames()
+		stack := make([]uintptr, len(stackframes))
+		for i, stackframe := range stackframes {
+			stack[i] = stackframe.ProgramCounter
+		}
+
+		return &Error{
+			Err:   e,
+			stack: stack,
+		}
 	case ErrorWithCallers:
 		return &Error{
 			Err:   e,

--- a/errors/error.go
+++ b/errors/error.go
@@ -4,9 +4,9 @@ package errors
 import (
 	"bytes"
 	"fmt"
+	GoErrors "github.com/go-errors/errors"
 	"reflect"
 	"runtime"
-	GoErrors "github.com/go-errors/errors"
 )
 
 // The maximum number of stackframes on any error.

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -3,6 +3,7 @@ package errors
 import (
 	"bytes"
 	"fmt"
+	GoErrors "github.com/go-errors/errors"
 	"io"
 	"runtime/debug"
 	"testing"
@@ -75,6 +76,19 @@ func TestNewError(t *testing.T) {
 	}
 }
 
+func TestNewGoError(t *testing.T) {
+	goError := goError()
+	bugsnagError := New(goError, 0)
+
+	goErrorStack := goError.(*GoErrors.Error).Stack()
+	bugsnagErrorStack := bugsnagError.Stack()
+	if bytes.Compare(goErrorStack, bugsnagErrorStack) != 0 {
+		t.Errorf("Stack didn't match")
+		t.Errorf("%s", goErrorStack)
+		t.Errorf("%s", bugsnagErrorStack)
+	}
+}
+
 func ExampleErrorf() {
 	for i := 1; i <= 2; i++ {
 		if i%2 == 1 {
@@ -123,4 +137,12 @@ func b(i int) {
 
 func c() {
 	panic('a')
+}
+
+func goError() error {
+	return getGoError()
+}
+
+func getGoError() error {
+	return GoErrors.New(GoErrors.Errorf("oh dear"))
 }


### PR DESCRIPTION
Allows the stack from a passed in errors object from the [go-errors/errors](https://github.com/go-errors/errors) package to be used when passed to bugsnag.Notify rather than using the stack from the point in which notify was called.