### PR TITLE
Mend nil-pointer panic

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -101,6 +101,9 @@ func (s sanitizer) Sanitize(data interface{}) interface{} {
 		return data
 
 	case reflect.Interface, reflect.Ptr:
+		if v.IsNil() {
+			return "<nil>"
+		}
 		return s.Sanitize(v.Elem().Interface())
 
 	case reflect.Array, reflect.Slice:

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -172,6 +172,26 @@ func TestMetaDataSanitize(t *testing.T) {
 
 }
 
+func TestSanitizerSanitize(t *testing.T) {
+	var (
+		nilPointer *int
+	)
+
+	for n, tc := range []struct {
+		input interface{}
+		want  interface{}
+	}{
+		{nilPointer, "<nil>"},
+	} {
+		s := &sanitizer{}
+		gotValue := s.Sanitize(tc.input)
+
+		if got, want := gotValue, tc.want; got != want {
+			t.Errorf("[%d] got %v, want %v", n, got, want)
+		}
+	}
+}
+
 func ExampleMetaData() {
 	notifier.Notify(errors.Errorf("hi world"),
 		MetaData{"Account": {


### PR DESCRIPTION
Given a nil pointer value, sanitizer.Sanitize panics when trying to call
Elem().Interface() on it. Fix by checking for nil pointer before trying
to retreive the underlying value.