### PR TITLE
Improve goroutine handling

### DIFF
--- a/bugsnag.go
+++ b/bugsnag.go
@@ -48,7 +48,7 @@ func Notify(err error, rawData ...interface{}) error {
 func AutoNotify(rawData ...interface{}) {
 	if err := recover(); err != nil {
 		rawData = defaultNotifier.addDefaultSeverity(rawData, SeverityError)
-		defaultNotifier.Notify(errors.New(err, 2), rawData...)
+		defaultNotifier.NotifySync(errors.New(err, 2), true, rawData...)
 		panic(err)
 	}
 }

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -42,9 +42,14 @@ func Notify(err error, rawData ...interface{}) error {
 
 // AutoNotify logs a panic on a goroutine and then repanics.
 // It should only be used in places that have existing panic handlers further
-// up the stack. See bugsnag.Recover().  The rawData is used to send extra
-// information along with any panics that are handled this way.
-// Usage: defer bugsnag.AutoNotify()
+// up the stack. The rawData is used to send extra information along with any
+// panics that are handled this way.
+// Usage:
+//  go func() {
+//		defer bugsnag.AutoNotify()
+//      // (possibly crashy code)
+//  }()
+// See also: bugsnag.Recover()
 func AutoNotify(rawData ...interface{}) {
 	if err := recover(); err != nil {
 		rawData = defaultNotifier.addDefaultSeverity(rawData, SeverityError)

--- a/examples/using-goroutines/main.go
+++ b/examples/using-goroutines/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"github.com/bugsnag/bugsnag-go"
+	"sync"
+)
+
+func main() {
+	// Initialize Bugsnag with your API key
+	bugsnag.Configure(bugsnag.Configuration{
+		APIKey: "YOUR-API-KEY-HERE",
+	})
+	runProcesses()
+}
+
+func runProcesses() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// AutoNotify captures any panics, repanicking after error reports
+		// are sent
+		defer bugsnag.AutoNotify()
+
+		var object struct{}
+		crash(object)
+	}()
+
+	wg.Wait()
+}
+
+func crash(a interface{}) string {
+	return a.(string)
+}

--- a/notifier.go
+++ b/notifier.go
@@ -34,13 +34,22 @@ func New(rawData ...interface{}) *Notifier {
 // Bugsnag after being converted to JSON. e.g. bugsnag.SeverityError, bugsnag.Context,
 // or bugsnag.MetaData.
 func (notifier *Notifier) Notify(err error, rawData ...interface{}) (e error) {
+	config := notifier.Config
+	return notifier.NotifySync(err, config.Synchronous, rawData...)
+}
+
+// NotifySync sends an error to Bugsnag. The synchronous parameter specifies
+// whether to send the report in the current context. Any rawData you pass here
+// will be sent to Bugsnag after being converted to JSON. e.g.
+// bugsnag.SeverityError,  bugsnag.Context, or bugsnag.MetaData.
+func (notifier *Notifier) NotifySync(err error, synchronous bool, rawData ...interface{}) (e error) {
 	event, config := newEvent(errors.New(err, 1), rawData, notifier)
 
 	// Never block, start throwing away errors if we have too many.
 	e = middleware.Run(event, config, func() error {
 		config.logf("notifying bugsnag: %s", event.Message)
 		if config.notifyInReleaseStage() {
-			if config.Synchronous {
+			if synchronous {
 				return (&payload{event, config}).deliver()
 			}
 			// Ensure that any errors are logged if they occur in a goroutine.

--- a/notifier.go
+++ b/notifier.go
@@ -73,7 +73,11 @@ func (notifier *Notifier) NotifySync(err error, synchronous bool, rawData ...int
 
 // AutoNotify notifies Bugsnag of any panics, then repanics.
 // It sends along any rawData that gets passed in.
-// Usage: defer AutoNotify()
+// Usage:
+//  go func() {
+//		defer AutoNotify()
+//      // (possibly crashy code)
+//  }()
 func (notifier *Notifier) AutoNotify(rawData ...interface{}) {
 	if err := recover(); err != nil {
 		rawData = notifier.addDefaultSeverity(rawData, SeverityError)


### PR DESCRIPTION
When an unhandled panic occurs in a goroutine and the configuration specifies that error reports are delivered to bugsnag asynchronously, there is the potential for the crash and cleanup to occur before the report is sent. 

This change specifies that panics captured via `AutoNotify` are delivered synchronously before repanicking, ensuring that delivery occurs before shutdown. It also includes some small improvements to the documentation and an addition to the examples for using the library within goroutines.

To accompany this change will be a new section of the Go integration guide on docs.bugsnag.com on panic handling in goroutines.

Fixes #47 