### PR TITLE
Cleanup example documentation, create landing

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,25 @@
+# Examples of working with bugsnag-go
+
+This library has extensions for several use cases and web frameworks, and this
+directory includes many examples. Most examples can be run by fetching
+dependencies, inserting your API key, and using `go run`:
+
+```
+$ go get [example]/main.go
+$ go run [example]/main.go
+```
+
+Other examples (such as App Engine) include separate instructions with
+additional steps.
+
+## Use cases
+
+* [Capturing panics within goroutines](using-goroutines). Goroutines require
+  special care to avoid crashing the app entirely or cleaning up before an error
+  report can be sent. This is an example of a panic within a goroutine which is
+  sent to Bugsnag.
+* [Deploying to Google App Engine](appengine)
+* [Using Gin](gin) (web framework)
+* [Using net/http](http)
+* [Using Negroni](negroni) (web framework)
+* [Using Revel](revel) (web framework)

--- a/examples/appengine/README.md
+++ b/examples/appengine/README.md
@@ -1,10 +1,14 @@
 This is an example google app-engine app.
 
-To use it you will need to install the [App Engine
-SDK](https://cloud.google.com/appengine/downloads) for Go.
+## Configuration
+
+1. Install the [App Engine SDK](https://cloud.google.com/appengine/downloads)
+   for Go.
+2. Insert your Bugsnag API key in `hello.go`
 
 Then run:
 
     goapp deploy
 
-Then open: https://bugsnag-test.appspot.com/ in your web-browser.
+Open https://bugsnag-test.appspot.com/ in your web-browser to create error
+reports.

--- a/examples/appengine/hello.go
+++ b/examples/appengine/hello.go
@@ -2,10 +2,9 @@ package mellow
 
 import (
 	"fmt"
+	"github.com/bugsnag/bugsnag-go"
 	"net/http"
 	"os"
-
-	"github.com/bugsnag/bugsnag-go"
 )
 
 func init() {
@@ -13,8 +12,10 @@ func init() {
 		event.MetaData.AddStruct("original", event.Error.StackFrames())
 		return nil
 	})
+
+	// Insert your API key
 	bugsnag.Configure(bugsnag.Configuration{
-		APIKey: "066f5ad3590596f9aa8d601ea89af845",
+		APIKey: "YOUR-API-KEY-HERE",
 	})
 
 	http.HandleFunc("/", bugsnag.HandlerFunc(handler))

--- a/examples/gin/main.go
+++ b/examples/gin/main.go
@@ -1,41 +1,42 @@
 package main
 
 import (
-  "github.com/bugsnag/bugsnag-go"
-  "github.com/bugsnag/bugsnag-go/gin"
-  "github.com/gin-gonic/gin"
-  "net/http"
-  "os"
+	"github.com/bugsnag/bugsnag-go"
+	"github.com/bugsnag/bugsnag-go/gin"
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"os"
 )
 
 func main() {
 
-    g := gin.Default()
+	g := gin.Default()
 
-    g.Use(bugsnaggin.AutoNotify(bugsnag.Configuration{
-      APIKey: "YOUR API KEY",
-    }))
+	// Insert your API key
+	g.Use(bugsnaggin.AutoNotify(bugsnag.Configuration{
+		APIKey: "YOUR-API-KEY-HERE",
+	}))
 
-    g.GET("/crash", performUnhandledCrash)
-    g.GET("/handled", performHandledCrash)
+	g.GET("/crash", performUnhandledCrash)
+	g.GET("/handled", performHandledCrash)
 
-    g.Run(":9001") // listen and serve on 0.0.0.0:9001
+	g.Run(":9001") // listen and serve on 0.0.0.0:9001
 }
 
 func performUnhandledCrash(c *gin.Context) {
-  c.String(http.StatusOK, "OK")
-  var a struct{}
-  crash(a)
+	c.String(http.StatusOK, "OK")
+	var a struct{}
+	crash(a)
 }
 
 func performHandledCrash(c *gin.Context) {
-  _, err := os.Open("some_nonexistent_file.txt")
-  if err != nil {
-    bugsnag.Notify(err)
-  }
-  c.String(http.StatusOK, "OK")
+	_, err := os.Open("some_nonexistent_file.txt")
+	if err != nil {
+		bugsnag.Notify(err)
+	}
+	c.String(http.StatusOK, "OK")
 }
 
 func crash(a interface{}) string {
-  return a.(string)
+	return a.(string)
 }

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -7,11 +7,11 @@ import (
 )
 
 func main() {
-
 	http.HandleFunc("/", Get)
 
+	// Insert your API key
 	bugsnag.Configure(bugsnag.Configuration{
-		APIKey: "066f5ad3590596f9aa8d601ea89af845",
+		APIKey: "YOUR-API-KEY-HERE",
 	})
 
 	log.Println("Serving on 9001")

--- a/examples/revelapp/README.md
+++ b/examples/revelapp/README.md
@@ -1,0 +1,11 @@
+# revel example
+
+## Configuration
+
+1. Install revel:
+
+       go get -u github.com/revel/cmd/revel
+
+2. Insert API key in `conf/app.conf`
+
+3. Run the app with `revel run`


### PR DESCRIPTION
The examples are somewhat in disarray at the moment, this change brings them into line as being somewhat similarly configured and adds a landing README for explaining what each one does.

Somewhat dependent on #52 (for the goroutine example)