### PR TITLE
fix: Strip GOPATH from callstack frame file paths

### DIFF
--- a/bugsnag.go
+++ b/bugsnag.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
+	"runtime"
 	"sync"
 
 	// Fixes a bug with SHA-384 intermediate certs on some platforms.
@@ -114,6 +116,12 @@ func init() {
 	OnBeforeNotify(httpRequestMiddleware)
 
 	// Default configuration
+	sourceRoot := ""
+	if gopath := os.Getenv("GOPATH"); len(gopath) > 0 {
+		sourceRoot = filepath.Join(gopath, "src") + "/"
+	} else {
+		sourceRoot = filepath.Join(runtime.GOROOT(), "src") + "/"
+	}
 	Config.update(&Configuration{
 		APIKey:        "",
 		Endpoint:      "https://notify.bugsnag.com/",
@@ -122,6 +130,7 @@ func init() {
 		AppVersion:    "",
 		ReleaseStage:  "",
 		ParamsFilters: []string{"password", "secret"},
+		SourceRoot:    sourceRoot,
 		// * for app-engine
 		ProjectPackages:     []string{"main*"},
 		NotifyReleaseStages: nil,

--- a/examples/gin/main.go
+++ b/examples/gin/main.go
@@ -4,8 +4,6 @@ import (
 	"github.com/bugsnag/bugsnag-go"
 	"github.com/bugsnag/bugsnag-go/gin"
 	"github.com/gin-gonic/gin"
-	"net/http"
-	"os"
 )
 
 func main() {
@@ -14,29 +12,11 @@ func main() {
 
 	// Insert your API key
 	g.Use(bugsnaggin.AutoNotify(bugsnag.Configuration{
-		APIKey: "YOUR-API-KEY-HERE",
+		APIKey:          "YOUR-API-KEY-HERE",
+		ProjectPackages: []string{"main", "github.com/bugsnag/bugsnag-go/examples/gin"},
 	}))
 
-	g.GET("/crash", performUnhandledCrash)
-	g.GET("/handled", performHandledCrash)
+	ConfigureRoutes(g)
 
 	g.Run(":9001") // listen and serve on 0.0.0.0:9001
-}
-
-func performUnhandledCrash(c *gin.Context) {
-	c.String(http.StatusOK, "OK")
-	var a struct{}
-	crash(a)
-}
-
-func performHandledCrash(c *gin.Context) {
-	_, err := os.Open("some_nonexistent_file.txt")
-	if err != nil {
-		bugsnag.Notify(err)
-	}
-	c.String(http.StatusOK, "OK")
-}
-
-func crash(a interface{}) string {
-	return a.(string)
 }

--- a/examples/gin/request.go
+++ b/examples/gin/request.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"github.com/bugsnag/bugsnag-go"
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"os"
+)
+
+func ConfigureRoutes(g *gin.Engine) {
+	g.GET("/crash", performUnhandledCrash)
+	g.GET("/handled", performHandledCrash)
+
+}
+
+func performUnhandledCrash(c *gin.Context) {
+	c.String(http.StatusOK, "OK")
+	var a struct{}
+	crash(a)
+}
+
+func performHandledCrash(c *gin.Context) {
+	_, err := os.Open("some_nonexistent_file.txt")
+	if err != nil {
+		bugsnag.Notify(err)
+	}
+	c.String(http.StatusOK, "OK")
+}
+
+func crash(a interface{}) string {
+	return a.(string)
+}


### PR DESCRIPTION
The file name component of a stack frame on bugsnag resolves to the full path at which a binary is built for any file which is not the entry point of the application. For example, building the gin example in commit 8e66a5f results in a path similar to:
```
/Users/[username]/path/to/go/code/src/github.com/bugsnag/bugsnag-go/examples/gin/request.go:31
``` 

The expected default is
```
github.com/bugsnag/bugsnag-go/examples/gin/request.go:31
```

Which can then be trimmed using the `ProjectPackages` option to 
```
request.go:31
```

Because of this problem, the same bug manifesting in two versions of a Go application built on two different machines resolves different stack frames when generating Bugsnag error reports.

This changeset updates an example to demonstrate the problem and adds a configuration option, `SourceRoot`, which defaults to `$GOPATH/src`/`$GOROOT/src` to trim variable prefixes in call stack file paths.


To test, run `examples/gin` using 8e66a5f (broken) and 5353812 (fixed! 🎉)