### PR TITLE
Switch loggo for logrus for more enterprise friendly licensing

### DIFF
--- a/configuration_test.go
+++ b/configuration_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/juju/loggo"
+	"github.com/sirupsen/logrus"
 )
 
 func TestNotifyReleaseStages(t *testing.T) {
@@ -174,11 +174,11 @@ func TestStripCustomSourceRoot(t *testing.T) {
 	}
 }
 
-type LoggoWrapper struct {
-	loggo.Logger
+type LogrusWrapper struct {
+	logrus.Logger
 }
 
-func (lw *LoggoWrapper) Printf(format string, v ...interface{}) {
+func (lw *LogrusWrapper) Printf(format string, v ...interface{}) {
 	lw.Logger.Warningf(format, v...)
 }
 
@@ -186,7 +186,7 @@ func TestConfiguringCustomLogger(t *testing.T) {
 
 	l1 := log.New(os.Stdout, "", log.Lshortfile)
 
-	l2 := &LoggoWrapper{loggo.GetLogger("test")}
+	l2 := &LogrusWrapper{*logrus.New()}
 
 	var testCases = []struct {
 		config Configuration


### PR DESCRIPTION
Hey, I'm not sure if you were aware but loggo is LGPL'd which is causing it to get flagged in the CNCF's license scanning tool: https://app.fossa.io

You only used loggo in one test for configuring customer loggers. Logrus, which is MIT licensed, meets the necessary interfaces so this PR switches loggo for logrus to resolve the licensing issue.

@xizhao can provide more context on licensing and why we're trying to avoid (L)GPL.

