### PR TITLE
Support Revel release v0.18.0

### DIFF
--- a/revel/bugsnagrevel.go
+++ b/revel/bugsnagrevel.go
@@ -37,7 +37,7 @@ func middleware(event *bugsnag.Event, config *bugsnag.Configuration) error {
 	for _, datum := range event.RawData {
 		if controller, ok := datum.(*revel.Controller); ok {
 			// make the request visible to the builtin HttpMiddleware
-			event.RawData = append(event.RawData, controller.Request.Request)
+			event.RawData = append(event.RawData, controller.Request)
 			event.Context = controller.Action
 			event.MetaData.AddStruct("Session", controller.Session)
 		}


### PR DESCRIPTION
Hello, 

Revel introduced breaking changes with v0.18.0 - [Changelog](https://github.com/revel/revel/blob/master/CHANGELOG.md). 

> http.Request is no longer contained in revel.Request revel.Request remains functionally the same but you cannot extract the http.Request from it. You can get the http.Request from revel.Controller.Request.In.GetRaw().(*http.Request)

