### PR TITLE
Session tracking delivery logic

### DIFF
--- a/bugsnag.go
+++ b/bugsnag.go
@@ -127,14 +127,18 @@ func init() {
 		sourceRoot = filepath.Join(runtime.GOROOT(), "src") + "/"
 	}
 	Config.update(&Configuration{
-		APIKey:        "",
-		Endpoint:      "https://notify.bugsnag.com/",
-		Hostname:      "",
-		AppType:       "",
-		AppVersion:    "",
-		ReleaseStage:  "",
-		ParamsFilters: []string{"password", "secret"},
-		SourceRoot:    sourceRoot,
+		APIKey: "",
+		Endpoints: Endpoints{
+			Notify:   "https://notify.bugsnag.com",
+			Sessions: "https://sessions.bugsnag.com",
+		},
+		Hostname:            "",
+		AppType:             "",
+		AppVersion:          "",
+		AutoCaptureSessions: true,
+		ReleaseStage:        "",
+		ParamsFilters:       []string{"password", "secret"},
+		SourceRoot:          sourceRoot,
 		// * for app-engine
 		ProjectPackages:     []string{"main*"},
 		NotifyReleaseStages: nil,

--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -74,7 +74,7 @@ func TestNotify(t *testing.T) {
 	Notify(fmt.Errorf("hello world"),
 		Configuration{
 			APIKey:          testAPIKey,
-			Endpoint:        testEndpoint,
+			Endpoints:       Endpoints{Notify: testEndpoint},
 			ReleaseStage:    "test",
 			AppType:         "foo",
 			AppVersion:      "1.2.3",
@@ -187,7 +187,7 @@ func TestHandler(t *testing.T) {
 
 	l, err := runCrashyServer(Configuration{
 		APIKey:          testAPIKey,
-		Endpoint:        testEndpoint,
+		Endpoints:       Endpoints{Notify: testEndpoint},
 		ProjectPackages: []string{"github.com/bugsnag/bugsnag-go"},
 		Logger:          log.New(ioutil.Discard, log.Prefix(), log.Flags()),
 	}, SeverityInfo)
@@ -272,7 +272,7 @@ func TestAutoNotify(t *testing.T) {
 		defer func() {
 			panicked = recover()
 		}()
-		defer AutoNotify(Configuration{Endpoint: testEndpoint, APIKey: testAPIKey})
+		defer AutoNotify(Configuration{Endpoints: Endpoints{Notify: testEndpoint}, APIKey: testAPIKey})
 
 		panic("eggs")
 	}()
@@ -306,7 +306,7 @@ func TestRecover(t *testing.T) {
 		defer func() {
 			panicked = recover()
 		}()
-		defer Recover(Configuration{Endpoint: testEndpoint, APIKey: testAPIKey})
+		defer Recover(Configuration{Endpoints: Endpoints{Notify: testEndpoint}, APIKey: testAPIKey})
 
 		panic("ham")
 	}()
@@ -367,7 +367,7 @@ func ExampleRecover() {
 	}
 
 	func() {
-		defer Recover(Configuration{Endpoint: testEndpoint, APIKey: testAPIKey})
+		defer Recover(Configuration{Endpoints: Endpoints{Notify: testEndpoint}, APIKey: testAPIKey})
 		job.Process()
 	}()
 	fmt.Println("Panic recovered")
@@ -528,7 +528,7 @@ func assertSeverityReasonEqual(t *testing.T, json *simplejson.Json, expSeverity 
 func generateSampleConfig() Configuration {
 	return Configuration{
 		APIKey:          testAPIKey,
-		Endpoint:        testEndpoint,
+		Endpoints:       Endpoints{Notify: testEndpoint},
 		ReleaseStage:    "test",
 		AppType:         "foo",
 		AppVersion:      "1.2.3",

--- a/configuration.go
+++ b/configuration.go
@@ -7,15 +7,32 @@ import (
 	"strings"
 )
 
+// Endpoints hold the HTTP endpoints of the notifier.
+type Endpoints struct {
+	Sessions string
+	Notify   string
+}
+
 // Configuration sets up and customizes communication with the Bugsnag API.
 type Configuration struct {
 	// Your Bugsnag API key, e.g. "c9d60ae4c7e70c4b6c4ebd3e8056d2b8". You can
 	// find this by clicking Settings on https://bugsnag.com/.
 	APIKey string
+
+	// Deprecated: Use Endpoints (with an 's') instead.
 	// The Endpoint to notify about crashes. This defaults to
 	// "https://notify.bugsnag.com/", if you're using Bugsnag Enterprise then
 	// set it to your internal Bugsnag endpoint.
 	Endpoint string
+	// Endpoints define the HTTP endpoints that the notifier should notify
+	// about crashes and sessions. These default to notify.bugsnag.com for
+	// error reports and sessions.bugsnag.com for sessions.
+	// If you are using bugsnag on-premise you will have to set these to your
+	// Event Server and Session Server endpoints. If the notify endpoint is set
+	// but the sessions endpoint is not, session tracking will be disabled
+	// automatically to avoid leaking session information outside of your
+	// server configuration, and a warning will be logged.
+	Endpoints Endpoints
 
 	// The current release stage. This defaults to "production" and is used to
 	// filter errors in the Bugsnag dashboard.

--- a/configuration.go
+++ b/configuration.go
@@ -109,9 +109,6 @@ func (config *Configuration) update(other *Configuration) *Configuration {
 	if other.APIKey != "" {
 		config.APIKey = other.APIKey
 	}
-	if other.Endpoint != "" {
-		config.Endpoint = other.Endpoint
-	}
 	if other.Hostname != "" {
 		config.Hostname = other.Hostname
 	}
@@ -135,6 +132,10 @@ func (config *Configuration) update(other *Configuration) *Configuration {
 	}
 	if other.Logger != nil {
 		config.Logger = other.Logger
+	}
+	if other.Endpoint != "" {
+		config.Logger.Printf("WARNING: the Bugsnag configuration parameter 'Endpoint' is deprecated in favor of 'Endpoints'")
+		config.Endpoint = other.Endpoint
 	}
 	if other.NotifyReleaseStages != nil {
 		config.NotifyReleaseStages = other.NotifyReleaseStages

--- a/configuration.go
+++ b/configuration.go
@@ -137,6 +137,12 @@ func (config *Configuration) update(other *Configuration) *Configuration {
 		config.Logger.Printf("WARNING: the Bugsnag configuration parameter 'Endpoint' is deprecated in favor of 'Endpoints'")
 		config.Endpoint = other.Endpoint
 	}
+	if other.Endpoints.Notify != "" {
+		config.Endpoints.Notify = other.Endpoints.Notify
+	}
+	if other.Endpoints.Sessions != "" {
+		config.Endpoints.Sessions = other.Endpoints.Sessions
+	}
 	if other.NotifyReleaseStages != nil {
 		config.NotifyReleaseStages = other.NotifyReleaseStages
 	}

--- a/configuration.go
+++ b/configuration.go
@@ -44,6 +44,16 @@ type Configuration struct {
 	// in the Bugsnag dasboard. If you set this then Bugsnag will only re-open
 	// resolved errors if they happen in different app versions.
 	AppVersion string
+
+	// AutoCaptureSessions can be set to false to disable automatic session
+	// tracking. If you want control over what is deemed a session, you can
+	// switch off automatic session tracking with this configuration, and call
+	// bugsnag.StartSession() when appropriate for your application. See the
+	// official docs for instructions and examples of associating handled
+	// errors with sessions and ensuring error rate accuracy on the Bugsnag
+	// dashboard.
+	AutoCaptureSessions bool
+
 	// The hostname of the current server. This defaults to the return value of
 	// os.Hostname() and is graphed in the Bugsnag dashboard.
 	Hostname string

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -210,20 +210,119 @@ func TestConfiguringCustomLogger(t *testing.T) {
 }
 
 func TestEndpointDeprecationWarning(t *testing.T) {
-	logger := &CustomTestLogger{[]string{}}
-	Config.update(&Configuration{
-		Endpoint: "https://doesnt.matter.com/",
-		Logger:   logger,
+	defaultNotify := "https://notify.bugsnag.com/"
+	defaultSessions := "https://sessions.bugsnag.com/"
+	setUp := func() (*Configuration, *CustomTestLogger) {
+		logger := &CustomTestLogger{}
+		return &Configuration{
+			Endpoints: Endpoints{
+				Notify:   defaultNotify,
+				Sessions: defaultSessions,
+			},
+			Logger: logger,
+		}, logger
+	}
+
+	t.Run("Setting Endpoint gives deprecation warning", func(st *testing.T) {
+		c, logger := setUp()
+		config := Configuration{Endpoint: "https://endpoint.whatever.com/"}
+		c.update(&config)
+		if got := logger.loggedMessages; len(got) != 1 {
+			st.Errorf("Expected exactly one logged message but got %d: %v", len(got), got)
+		}
+		got := logger.loggedMessages[0]
+		for _, exp := range []string{"WARNING", "Bugsnag", "Endpoint", "Endpoints", "deprecated"} {
+			if !strings.Contains(got, exp) {
+				st.Errorf("Expected logger message containing '%s' when configuring but got %s.", exp, got)
+			}
+		}
+		if got, exp := c.Endpoints.Notify, config.Endpoint; got != exp {
+			st.Errorf("Expected notify endpoint '%s' but got '%s'", exp, got)
+		}
+		if got, exp := c.Endpoints.Sessions, ""; got != exp {
+			st.Errorf("Expected sessions endpoint '%s' but got '%s'", exp, got)
+		}
 	})
 
-	if len(logger.loggedMessages) != 1 {
-		t.Errorf("Expected a deprecation warning when configuring endpoints.")
-	}
-	got := logger.loggedMessages[0]
-	keywords := []string{"WARNING", "Bugsnag", "Endpoint", "deprecated"}
-	for _, w := range keywords {
-		if !strings.Contains(got, w) {
-			t.Errorf("Expected deprecation warning containing '%s' when configuring Endpoint but got %s.", w, got)
+	t.Run("Setting Endpoints.Notify without setting Endpoints.Sessions gives session disabled warning", func(st *testing.T) {
+		c, logger := setUp()
+		config := Configuration{
+			Endpoints: Endpoints{
+				Notify: "https://notify.whatever.com/",
+			},
 		}
-	}
+		keywords := []string{"WARNING", "Bugsnag", "notify", "No sessions"}
+		c.update(&config)
+		if got := len(logger.loggedMessages); got != 1 {
+			st.Errorf("Expected exactly one logged message but got %d", got)
+		}
+		got := logger.loggedMessages[0]
+		for _, exp := range keywords {
+			if !strings.Contains(got, exp) {
+				st.Errorf("Expected logger message containing '%s' when configuring but got %s.", exp, got)
+			}
+		}
+		if got, exp := c.Endpoints.Notify, config.Endpoints.Notify; got != exp {
+			st.Errorf("Expected notify endpoint to be '%s' but was '%s'", exp, got)
+		}
+		if got, exp := c.Endpoints.Sessions, ""; got != exp {
+			st.Errorf("Expected sessions endpoint to be '%s' but was '%s'", exp, got)
+		}
+	})
+
+	t.Run("Setting Endpoints.Sessions without setting Endpoints.Notify should panic", func(st *testing.T) {
+		c, _ := setUp()
+		defer func() {
+			if err := recover(); err != nil {
+				got := err.(string)
+				for _, exp := range []string{"FATAL", "Bugsnag", "notify", "sessions"} {
+					if !strings.Contains(got, exp) {
+						st.Errorf("Expected panic error containing '%s' when configuring but got %s.", exp, got)
+					}
+				}
+			} else {
+				st.Errorf("Expected a panic to happen but didn't")
+			}
+		}()
+		c.update(&Configuration{
+			Endpoints: Endpoints{
+				Sessions: "https://sessions.whatever.com/",
+			},
+		})
+	})
+
+	t.Run("Should not complain if both Endpoints.Notify and Endpoints.Sessions are configured", func(st *testing.T) {
+		notifyEndpoint, sessionsEndpoint := "https://notify.whatever.com", "https://sessions.whatever.com"
+		config := Configuration{
+			Endpoints: Endpoints{
+				Notify:   notifyEndpoint,
+				Sessions: sessionsEndpoint,
+			},
+		}
+		c, logger := setUp()
+		c.update(&config)
+		if len(logger.loggedMessages) != 0 {
+			st.Errorf("Did not expect any messages to be logged but logged: %v", logger.loggedMessages)
+		}
+		if got, exp := c.Endpoints.Notify, notifyEndpoint; got != exp {
+			st.Errorf("Expected Notify endpoint: '%s', but was: '%s'", exp, got)
+		}
+		if got, exp := c.Endpoints.Sessions, sessionsEndpoint; got != exp {
+			st.Errorf("Expected Sessions endpoint: '%s', but was: '%s'", exp, got)
+		}
+	})
+
+	t.Run("Should not complain if Endpoints are not configured", func(st *testing.T) {
+		c, logger := setUp()
+		c.update(&Configuration{})
+		if len(logger.loggedMessages) != 0 {
+			st.Errorf("Did not expect any messages to be logged but logged: %v", logger.loggedMessages)
+		}
+		if got, exp := c.Endpoints.Notify, defaultNotify; got != exp {
+			st.Errorf("Expected Notify endpoint: '%s', but was: '%s'", exp, got)
+		}
+		if got, exp := c.Endpoints.Sessions, defaultSessions; got != exp {
+			st.Errorf("Expected Sessions endpoint: '%s', but was: '%s'", exp, got)
+		}
+	})
 }

--- a/headers.go
+++ b/headers.go
@@ -1,0 +1,12 @@
+package bugsnag
+
+import "time"
+
+func bugsnagPrefixedHeaders(apiKey string) map[string]string {
+	return map[string]string{
+		"Content-Type":            "application/json",
+		"Bugsnag-Api-Key":         apiKey,
+		"Bugsnag-Payload-Version": "1",
+		"Bugsnag-Sent-At":         time.Now().Format(time.RFC3339),
+	}
+}

--- a/headers.go
+++ b/headers.go
@@ -2,11 +2,11 @@ package bugsnag
 
 import "time"
 
-func bugsnagPrefixedHeaders(apiKey string) map[string]string {
+func bugsnagPrefixedHeaders(apiKey, payloadVersion string) map[string]string {
 	return map[string]string{
 		"Content-Type":            "application/json",
 		"Bugsnag-Api-Key":         apiKey,
-		"Bugsnag-Payload-Version": "1",
+		"Bugsnag-Payload-Version": payloadVersion,
 		"Bugsnag-Sent-At":         time.Now().Format(time.RFC3339),
 	}
 }

--- a/headers_test.go
+++ b/headers_test.go
@@ -1,0 +1,41 @@
+package bugsnag
+
+import (
+	"testing"
+	"time"
+)
+
+const APIKey = "abcd1234abcd1234"
+
+func TestConstantBugsnagPrefixedHeaders(t *testing.T) {
+	headers := bugsnagPrefixedHeaders(APIKey)
+	testCases := []struct {
+		header   string
+		expected string
+	}{
+		{header: "Content-Type", expected: "application/json"},
+		{header: "Bugsnag-Api-Key", expected: APIKey},
+		{header: "Bugsnag-Payload-Version", expected: "1"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.header, func(st *testing.T) {
+			if got := headers[tc.header]; got != tc.expected {
+				t.Errorf("Expected headers to contain %s header %s but was %s", tc.header, tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimeDependentBugsnagPrefixedHeaders(t *testing.T) {
+	headers := bugsnagPrefixedHeaders(APIKey)
+	sentAtString := headers["Bugsnag-Sent-At"]
+	sentAt, err := time.Parse(time.RFC3339, sentAtString)
+
+	if err != nil {
+		t.Errorf("Error when attempting to parse Bugsnag-Sent-At header: %s", sentAtString)
+	}
+
+	if now := time.Now(); now.Sub(sentAt) > time.Second || now.Sub(sentAt) < -time.Second {
+		t.Errorf("Expected Bugsnag-Sent-At header approx. %s but was %s", now.UTC().Format(time.RFC3339), sentAtString)
+	}
+}

--- a/headers_test.go
+++ b/headers_test.go
@@ -6,16 +6,17 @@ import (
 )
 
 const APIKey = "abcd1234abcd1234"
+const testPayloadVersion = "3"
 
 func TestConstantBugsnagPrefixedHeaders(t *testing.T) {
-	headers := bugsnagPrefixedHeaders(APIKey)
+	headers := bugsnagPrefixedHeaders(APIKey, testPayloadVersion)
 	testCases := []struct {
 		header   string
 		expected string
 	}{
 		{header: "Content-Type", expected: "application/json"},
 		{header: "Bugsnag-Api-Key", expected: APIKey},
-		{header: "Bugsnag-Payload-Version", expected: "1"},
+		{header: "Bugsnag-Payload-Version", expected: testPayloadVersion},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.header, func(st *testing.T) {
@@ -27,7 +28,7 @@ func TestConstantBugsnagPrefixedHeaders(t *testing.T) {
 }
 
 func TestTimeDependentBugsnagPrefixedHeaders(t *testing.T) {
-	headers := bugsnagPrefixedHeaders(APIKey)
+	headers := bugsnagPrefixedHeaders(APIKey, testPayloadVersion)
 	sentAtString := headers["Bugsnag-Sent-At"]
 	sentAt, err := time.Parse(time.RFC3339, sentAtString)
 

--- a/panicwrap_test.go
+++ b/panicwrap_test.go
@@ -69,7 +69,7 @@ func startPanickingProcess(t *testing.T, variant string) {
 	// Use the same trick as panicwrap() to re-run ourselves.
 	// In the init() block below, we will then panic.
 	cmd := exec.Command(exePath, os.Args[1:]...)
-	cmd.Env = append(os.Environ(), "BUGSNAG_API_KEY="+testAPIKey, "BUGSNAG_ENDPOINT="+testEndpoint, "please_panic="+variant)
+	cmd.Env = append(os.Environ(), "BUGSNAG_API_KEY="+testAPIKey, "BUGSNAG_NOTIFY_ENDPOINT="+testEndpoint, "please_panic="+variant)
 
 	if err = cmd.Start(); err != nil {
 		t.Fatal(err)
@@ -84,7 +84,7 @@ func init() {
 	if os.Getenv("please_panic") == "handled" {
 		Configure(Configuration{
 			APIKey:          os.Getenv("BUGSNAG_API_KEY"),
-			Endpoint:        os.Getenv("BUGSNAG_ENDPOINT"),
+			Endpoints:       Endpoints{Notify: os.Getenv("BUGSNAG_NOTIFY_ENDPOINT")},
 			ProjectPackages: []string{"github.com/bugsnag/bugsnag-go"}})
 		go func() {
 			defer AutoNotify()
@@ -96,7 +96,7 @@ func init() {
 	} else if os.Getenv("please_panic") == "unhandled" {
 		Configure(Configuration{
 			APIKey:          os.Getenv("BUGSNAG_API_KEY"),
-			Endpoint:        os.Getenv("BUGSNAG_ENDPOINT"),
+			Endpoints:       Endpoints{Notify: os.Getenv("BUGSNAG_NOTIFY_ENDPOINT")},
 			Synchronous:     true,
 			ProjectPackages: []string{"github.com/bugsnag/bugsnag-go"}})
 		panick()

--- a/payload.go
+++ b/payload.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 )
 
+const notifyPayloadVersion = "2"
+
 type payload struct {
 	*Event
 	*Configuration
@@ -33,7 +35,7 @@ func (p *payload) deliver() error {
 	if err != nil {
 		return fmt.Errorf("bugsnag/payload.deliver unable to create request: %v", err)
 	}
-	for k, v := range bugsnagPrefixedHeaders(p.APIKey) {
+	for k, v := range bugsnagPrefixedHeaders(p.APIKey, notifyPayloadVersion) {
 		req.Header.Add(k, v)
 	}
 	resp, err := client.Do(req)
@@ -71,7 +73,7 @@ func (p *payload) MarshalJSON() ([]byte, error) {
 
 		"events": []hash{
 			{
-				"payloadVersion": "2",
+				"payloadVersion": notifyPayloadVersion,
 				"exceptions": []hash{
 					{
 						"errorClass": p.ErrorClass,

--- a/payload.go
+++ b/payload.go
@@ -30,7 +30,7 @@ func (p *payload) deliver() error {
 		Transport: p.Transport,
 	}
 
-	resp, err := client.Post(p.Endpoint, "application/json", bytes.NewBuffer(buf))
+	resp, err := client.Post(p.Endpoints.Notify, "application/json", bytes.NewBuffer(buf))
 
 	if err != nil {
 		return fmt.Errorf("bugsnag/payload.deliver: %v", err)

--- a/revel/bugsnagrevel.go
+++ b/revel/bugsnagrevel.go
@@ -64,8 +64,11 @@ func init() {
 		}
 
 		bugsnag.Configure(bugsnag.Configuration{
-			APIKey:          revel.Config.StringDefault("bugsnag.apikey", ""),
-			Endpoint:        revel.Config.StringDefault("bugsnag.endpoint", ""),
+			APIKey: revel.Config.StringDefault("bugsnag.apikey", ""),
+			Endpoints: bugsnag.Endpoints{
+				Notify:   revel.Config.StringDefault("bugsnag.endpoints.notify", ""),
+				Sessions: revel.Config.StringDefault("bugsnag.endpoints.sessions", ""),
+			},
 			AppType:         revel.Config.StringDefault("bugsnag.apptype", ""),
 			AppVersion:      revel.Config.StringDefault("bugsnag.appversion", ""),
 			ReleaseStage:    revel.Config.StringDefault("bugsnag.releasestage", revel.RunMode),

--- a/session.go
+++ b/session.go
@@ -1,0 +1,75 @@
+package bugsnag
+
+import (
+	"os"
+	"runtime"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+)
+
+type session struct {
+	startedAt time.Time
+	id        uuid.UUID
+}
+
+type notifierPayload struct {
+	Name    string `json:"name"`
+	URL     string `json:"url"`
+	Version string `json:"version"`
+}
+
+type appPayload struct {
+	Type         string `json:"type"`
+	ReleaseStage string `json:"releaseStage"`
+	Version      string `json:"version"`
+}
+
+type devicePayload struct {
+	OsName   string `json:"osName"`
+	Hostname string `json:"hostname"`
+}
+
+type sessionCountsPayload struct {
+	StartedAt       string `json:"startedAt"`
+	SessionsStarted int    `json:"sessionsStarted"`
+}
+
+type sessionPayload struct {
+	Notifier      notifierPayload      `json:"notifier"`
+	App           appPayload           `json:"app"`
+	Device        devicePayload        `json:"device"`
+	SessionCounts sessionCountsPayload `json:"sessionCounts"`
+}
+
+func makeSessionPayload(sessions []session, config Configuration) sessionPayload {
+	releaseStage := config.ReleaseStage
+	if releaseStage == "" {
+		releaseStage = "production"
+	}
+	hostname := config.Hostname
+	if hostname == "" {
+		hostname, _ = os.Hostname() //Ignore the hostname if this call errors
+	}
+
+	return sessionPayload{
+		Notifier: notifierPayload{
+			Name:    "Bugsnag Go",
+			URL:     "https://github.com/bugsnag/bugsnag-go",
+			Version: VERSION,
+		},
+		App: appPayload{
+			Type:         config.AppType,
+			Version:      config.AppVersion,
+			ReleaseStage: releaseStage,
+		},
+		Device: devicePayload{
+			OsName:   runtime.GOOS,
+			Hostname: hostname,
+		},
+		SessionCounts: sessionCountsPayload{
+			StartedAt:       sessions[0].startedAt.UTC().Format(time.RFC3339),
+			SessionsStarted: len(sessions),
+		},
+	}
+}

--- a/session.go
+++ b/session.go
@@ -12,6 +12,8 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+const sessionPayloadVersion = "1"
+
 type session struct {
 	startedAt time.Time
 	id        uuid.UUID
@@ -57,7 +59,7 @@ func deliverSessions(sessions []session, config Configuration) error {
 	if err != nil {
 		return fmt.Errorf("bugsnag/session.deliverSession unable to create request: %v", err)
 	}
-	for k, v := range bugsnagPrefixedHeaders(config.APIKey) {
+	for k, v := range bugsnagPrefixedHeaders(config.APIKey, sessionPayloadVersion) {
 		req.Header.Add(k, v)
 	}
 	_, err = client.Do(req)

--- a/session_test.go
+++ b/session_test.go
@@ -1,0 +1,81 @@
+package bugsnag
+
+import (
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+)
+
+func TestBuildsCorrectPayloadWithMinimalConfig(t *testing.T) {
+	earliestTime := time.Now()
+	sessions := []session{
+		{startedAt: earliestTime, id: uuid.NewV4()},
+		{startedAt: earliestTime.Add(2 * time.Minute), id: uuid.NewV4()},
+		{startedAt: earliestTime.Add(4 * time.Minute), id: uuid.NewV4()},
+	}
+
+	sp := makeSessionPayload(sessions, Configuration{})
+
+	hostname, _ := os.Hostname()
+	testCases := []struct {
+		property string
+		expected string
+		got      string
+	}{
+		{property: "notifier name", expected: "Bugsnag Go", got: sp.Notifier.Name},
+		{property: "notifier URL", expected: "https://github.com/bugsnag/bugsnag-go", got: sp.Notifier.URL},
+		{property: "notifier version", expected: VERSION, got: sp.Notifier.Version},
+		{property: "app type", expected: "", got: sp.App.Type},
+		{property: "app release stage", expected: "production", got: sp.App.ReleaseStage},
+		{property: "app version", expected: "", got: sp.App.Version},
+		{property: "device OS", expected: runtime.GOOS, got: sp.Device.OsName},
+		{property: "device hostname", expected: hostname, got: sp.Device.Hostname},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.property, func(st *testing.T) {
+			if tc.got != tc.expected {
+				t.Errorf("Expected %s '%s' but got '%s'", tc.property, tc.expected, tc.got)
+			}
+		})
+	}
+
+	if expected, got := earliestTime.UTC().Format(time.RFC3339), sp.SessionCounts.StartedAt; got != expected {
+		t.Errorf("Expected the timestamp for sessions to be the earliest timestamp (%s), but was %s", expected, got)
+	}
+	if expected, got := 3, sp.SessionCounts.SessionsStarted; expected != got {
+		t.Errorf("Expected the count of sessions %d, but was %d", expected, got)
+	}
+}
+
+func TestBuildsCorrectPayloadFromConfig(t *testing.T) {
+	config := Configuration{
+		AppType:      "gin",
+		AppVersion:   "1.2.3-beta",
+		ReleaseStage: "staging",
+		Hostname:     "gce-1234-us-west-1",
+	}
+	sp := makeSessionPayload([]session{{startedAt: time.Now(), id: uuid.NewV4()}}, config)
+
+	testCases := []struct {
+		property string
+		expected string
+		got      string
+	}{
+		{property: "app type", expected: config.AppType, got: sp.App.Type},
+		{property: "app release stage", expected: config.ReleaseStage, got: sp.App.ReleaseStage},
+		{property: "app version", expected: config.AppVersion, got: sp.App.Version},
+		{property: "device hostname", expected: config.Hostname, got: sp.Device.Hostname},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.property, func(st *testing.T) {
+			if tc.got != tc.expected {
+				t.Errorf("Expected %s '%s' but got '%s'", tc.property, tc.expected, tc.got)
+			}
+		})
+	}
+}

--- a/session_test.go
+++ b/session_test.go
@@ -200,7 +200,7 @@ func assertSessionsStarted(t *testing.T, root *json.RawMessage, expected int) {
 func assertCorrectHeaders(t *testing.T) {
 	header := <-receivedSessionsHeaders
 	testCases := []struct{ name, expected string }{
-		{name: "Bugsnag-Payload-Version", expected: "1"},
+		{name: "Bugsnag-Payload-Version", expected: "1.0"},
 		{name: "Content-Type", expected: "application/json"},
 		{name: "Bugsnag-Api-Key", expected: testAPIKey},
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -1,81 +1,218 @@
 package bugsnag
 
 import (
+	"encoding/json"
+	"io/ioutil"
+	"net"
+	"net/http"
 	"os"
 	"runtime"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	uuid "github.com/satori/go.uuid"
 )
 
-func TestBuildsCorrectPayloadWithMinimalConfig(t *testing.T) {
-	earliestTime := time.Now()
-	sessions := []session{
-		{startedAt: earliestTime, id: uuid.NewV4()},
-		{startedAt: earliestTime.Add(2 * time.Minute), id: uuid.NewV4()},
-		{startedAt: earliestTime.Add(4 * time.Minute), id: uuid.NewV4()},
+const sessionAuthority string = "localhost:9182"
+
+var receivedSessionsPayloads = make(chan []byte, 10)
+var receivedSessionsHeaders = make(chan http.Header, 10)
+var sessionTestOnce sync.Once
+
+func TestSendsCorrectPayloadForSmallConfig(t *testing.T) {
+	startSessionTestServer()
+	sessions, earliestTime := makeSessions()
+	config := Configuration{
+		Endpoints: Endpoints{
+			Sessions: "http://" + sessionAuthority,
+		},
+		Transport: http.DefaultTransport,
+		APIKey:    testAPIKey,
 	}
-
-	sp := makeSessionPayload(sessions, Configuration{})
-
+	root := getLatestPayload(t, sessions, config)
+	assertCorrectHeaders(t)
 	hostname, _ := os.Hostname()
 	testCases := []struct {
 		property string
 		expected string
-		got      string
 	}{
-		{property: "notifier name", expected: "Bugsnag Go", got: sp.Notifier.Name},
-		{property: "notifier URL", expected: "https://github.com/bugsnag/bugsnag-go", got: sp.Notifier.URL},
-		{property: "notifier version", expected: VERSION, got: sp.Notifier.Version},
-		{property: "app type", expected: "", got: sp.App.Type},
-		{property: "app release stage", expected: "production", got: sp.App.ReleaseStage},
-		{property: "app version", expected: "", got: sp.App.Version},
-		{property: "device OS", expected: runtime.GOOS, got: sp.Device.OsName},
-		{property: "device hostname", expected: hostname, got: sp.Device.Hostname},
+		{property: "notifier.name", expected: "Bugsnag Go"},
+		{property: "notifier.url", expected: "https://github.com/bugsnag/bugsnag-go"},
+		{property: "notifier.version", expected: VERSION},
+		{property: "app.type", expected: ""},
+		{property: "app.releaseStage", expected: "production"},
+		{property: "app.version", expected: ""},
+		{property: "device.osName", expected: runtime.GOOS},
+		{property: "device.hostname", expected: hostname},
+		{property: "sessionCounts.startedAt", expected: earliestTime},
 	}
-
 	for _, tc := range testCases {
 		t.Run(tc.property, func(st *testing.T) {
-			if tc.got != tc.expected {
-				t.Errorf("Expected %s '%s' but got '%s'", tc.property, tc.expected, tc.got)
+			got, err := getJSONString(root, tc.property)
+			if err != nil {
+				t.Error(err)
+			}
+			if got != tc.expected {
+				t.Errorf("Expected property '%s' in JSON to be '%s' but was '%s'", tc.property, tc.expected, got)
 			}
 		})
 	}
-
-	if expected, got := earliestTime.UTC().Format(time.RFC3339), sp.SessionCounts.StartedAt; got != expected {
-		t.Errorf("Expected the timestamp for sessions to be the earliest timestamp (%s), but was %s", expected, got)
-	}
-	if expected, got := 3, sp.SessionCounts.SessionsStarted; expected != got {
-		t.Errorf("Expected the count of sessions %d, but was %d", expected, got)
-	}
+	assertSessionsStarted(t, root, len(sessions))
 }
 
-func TestBuildsCorrectPayloadFromConfig(t *testing.T) {
-	config := Configuration{
-		AppType:      "gin",
-		AppVersion:   "1.2.3-beta",
-		ReleaseStage: "staging",
-		Hostname:     "gce-1234-us-west-1",
-	}
-	sp := makeSessionPayload([]session{{startedAt: time.Now(), id: uuid.NewV4()}}, config)
-
+func TestSendsCorrectPayloadForBigConfig(t *testing.T) {
+	startSessionTestServer()
+	sessions, earliestTime := makeSessions()
+	root := getLatestPayload(t, sessions, makeHeavilyConfiguredConfig())
 	testCases := []struct {
 		property string
 		expected string
-		got      string
 	}{
-		{property: "app type", expected: config.AppType, got: sp.App.Type},
-		{property: "app release stage", expected: config.ReleaseStage, got: sp.App.ReleaseStage},
-		{property: "app version", expected: config.AppVersion, got: sp.App.Version},
-		{property: "device hostname", expected: config.Hostname, got: sp.Device.Hostname},
+		{property: "notifier.name", expected: "Bugsnag Go"},
+		{property: "notifier.url", expected: "https://github.com/bugsnag/bugsnag-go"},
+		{property: "notifier.version", expected: VERSION},
+		{property: "app.type", expected: "gin"},
+		{property: "app.releaseStage", expected: "staging"},
+		{property: "app.version", expected: "1.2.3-beta"},
+		{property: "device.osName", expected: runtime.GOOS},
+		{property: "device.hostname", expected: "gce-1234-us-west-1"},
+		{property: "sessionCounts.startedAt", expected: earliestTime},
 	}
-
 	for _, tc := range testCases {
 		t.Run(tc.property, func(st *testing.T) {
-			if tc.got != tc.expected {
-				t.Errorf("Expected %s '%s' but got '%s'", tc.property, tc.expected, tc.got)
+			got, err := getJSONString(root, tc.property)
+			if err != nil {
+				t.Error(err)
+			}
+			if got != tc.expected {
+				t.Errorf("Expected property '%s' in JSON to be '%s' but was '%s'", tc.property, tc.expected, got)
 			}
 		})
+	}
+	assertSessionsStarted(t, root, len(sessions))
+}
+
+func getJSONString(root *json.RawMessage, path string) (string, error) {
+	if strings.Contains(path, ".") {
+		split := strings.Split(path, ".")
+		subobj, err := getNestedJSON(root, split[0])
+		if err != nil {
+			return "", err
+		}
+		return getJSONString(subobj, strings.Join(split[1:], "."))
+	}
+	var m map[string]json.RawMessage
+	err := json.Unmarshal(*root, &m)
+	if err != nil {
+		return "", err
+	}
+	var s string
+	err = json.Unmarshal(m[path], &s)
+	if err != nil {
+		return "", err
+	}
+	return s, nil
+}
+
+func getNestedJSON(root *json.RawMessage, path string) (*json.RawMessage, error) {
+	var subobj map[string]*json.RawMessage
+	err := json.Unmarshal(*root, &subobj)
+	if err != nil {
+		return nil, err
+	}
+	return subobj[path], nil
+}
+
+func startSessionTestServer() {
+	sessionTestOnce.Do(func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				panic(err)
+			}
+			receivedSessionsPayloads <- body
+			receivedSessionsHeaders <- r.Header
+		})
+		l, err := net.Listen("tcp", sessionAuthority)
+		if err != nil {
+			panic(err)
+		}
+		go http.Serve(l, mux)
+	})
+}
+
+func makeHeavilyConfiguredConfig() Configuration {
+	return Configuration{
+		AppType:    "gin",
+		APIKey:     testAPIKey,
+		AppVersion: "1.2.3-beta",
+		Endpoints: Endpoints{
+			Sessions: "http://" + sessionAuthority,
+		},
+		Transport:    http.DefaultTransport,
+		ReleaseStage: "staging",
+		Hostname:     "gce-1234-us-west-1",
+	}
+}
+
+func makeSessions() ([]session, string) {
+	earliestTime := time.Now()
+	return []session{
+		{startedAt: earliestTime, id: uuid.NewV4()},
+		{startedAt: earliestTime.Add(2 * time.Minute), id: uuid.NewV4()},
+		{startedAt: earliestTime.Add(4 * time.Minute), id: uuid.NewV4()},
+	}, earliestTime.UTC().Format(time.RFC3339)
+}
+
+func getLatestPayload(t *testing.T, sessions []session, config Configuration) *json.RawMessage {
+	err := deliverSessions(sessions, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := <-receivedSessionsPayloads
+	var root json.RawMessage
+	err = json.Unmarshal(payload, &root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &root
+}
+
+func assertSessionsStarted(t *testing.T, root *json.RawMessage, expected int) {
+	subobj, err := getNestedJSON(root, "sessionCounts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sessionCounts map[string]*json.RawMessage
+	err = json.Unmarshal(*subobj, &sessionCounts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got int
+	err = json.Unmarshal(*sessionCounts["sessionsStarted"], &got)
+	if got != expected {
+		t.Errorf("Expected %d sessions to be registered but was %d", expected, got)
+	}
+}
+func assertCorrectHeaders(t *testing.T) {
+	header := <-receivedSessionsHeaders
+	testCases := []struct{ name, expected string }{
+		{name: "Bugsnag-Payload-Version", expected: "1"},
+		{name: "Content-Type", expected: "application/json"},
+		{name: "Bugsnag-Api-Key", expected: testAPIKey},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(st *testing.T) {
+			if got := header[tc.name][0]; tc.expected != got {
+				t.Errorf("Expected header '%s' to be '%s' but was '%s'", tc.name, tc.expected, got)
+			}
+		})
+	}
+	name := "Bugsnag-Sent-At"
+	if header[name][0] == "" {
+		t.Errorf("Expected header '%s' to be non-empty but was empty", name)
 	}
 }

--- a/tests/fixtures/gin.go
+++ b/tests/fixtures/gin.go
@@ -1,19 +1,23 @@
 package main
 
 import (
+	"net/http"
+	"os"
+
 	"github.com/bugsnag/bugsnag-go"
 	"github.com/bugsnag/bugsnag-go/gin"
 	"github.com/gin-gonic/gin"
-	"net/http"
-	"os"
 )
 
 func main() {
 	g := gin.Default()
 
 	g.Use(bugsnaggin.AutoNotify(bugsnag.Configuration{
-		APIKey:   "166f5ad3590596f9aa8d601ea89af845",
-		Endpoint: os.Getenv("BUGSNAG_ENDPOINT"),
+		APIKey: "166f5ad3590596f9aa8d601ea89af845",
+		Endpoints: bugsnag.Endpoints{
+			Notify:   os.Getenv("BUGSNAG_NOTIFY_ENDPOINT"),
+			Sessions: os.Getenv("BUGSNAG_SESSIONS_ENDPOINT"),
+		},
 	}))
 
 	if os.Getenv("BUGSNAG_TEST_VARIANT") == "beforenotify" {

--- a/tests/fixtures/martini.go
+++ b/tests/fixtures/martini.go
@@ -22,8 +22,8 @@ func main() {
 	})
 	m.Use(martini.Recovery())
 	m.Use(bugsnagmartini.AutoNotify(bugsnag.Configuration{
-		APIKey:   "166f5ad3590596f9aa8d601ea89af845",
-		Endpoint: os.Getenv("BUGSNAG_ENDPOINT"),
+		APIKey:    "166f5ad3590596f9aa8d601ea89af845",
+		Endpoints: bugsnag.Endpoints{Notify: os.Getenv("BUGSNAG_NOTIFY_ENDPOINT"), Sessions: os.Getenv("BUGSNAG_SESSIONS_ENDPOINT")},
 	}))
 	m.Run()
 }

--- a/tests/fixtures/negroni.go
+++ b/tests/fixtures/negroni.go
@@ -1,17 +1,18 @@
 package main
 
 import (
+	"net/http"
+	"os"
+
 	"github.com/bugsnag/bugsnag-go"
 	"github.com/bugsnag/bugsnag-go/negroni"
 	"github.com/urfave/negroni"
-	"net/http"
-	"os"
 )
 
 func main() {
 	errorReporterConfig := bugsnag.Configuration{
-		APIKey:   "166f5ad3590596f9aa8d601ea89af845",
-		Endpoint: os.Getenv("BUGSNAG_ENDPOINT"),
+		APIKey:    "166f5ad3590596f9aa8d601ea89af845",
+		Endpoints: bugsnag.Endpoints{Notify: os.Getenv("BUGSNAG_NOTIFY_ENDPOINT"), Sessions: os.Getenv("BUGSNAG_NOTIFY_ENDPOINT")},
 	}
 	if os.Getenv("BUGSNAG_TEST_VARIANT") == "beforenotify" {
 		bugsnag.OnBeforeNotify(func(event *bugsnag.Event, config *bugsnag.Configuration) error {

--- a/tests/fixtures/negroni.go
+++ b/tests/fixtures/negroni.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	errorReporterConfig := bugsnag.Configuration{
 		APIKey:    "166f5ad3590596f9aa8d601ea89af845",
-		Endpoints: bugsnag.Endpoints{Notify: os.Getenv("BUGSNAG_NOTIFY_ENDPOINT"), Sessions: os.Getenv("BUGSNAG_NOTIFY_ENDPOINT")},
+		Endpoints: bugsnag.Endpoints{Notify: os.Getenv("BUGSNAG_NOTIFY_ENDPOINT"), Sessions: os.Getenv("BUGSNAG_SESSIONS_ENDPOINT")},
 	}
 	if os.Getenv("BUGSNAG_TEST_VARIANT") == "beforenotify" {
 		bugsnag.OnBeforeNotify(func(event *bugsnag.Event, config *bugsnag.Configuration) error {

--- a/tests/fixtures/revel/app/init.go
+++ b/tests/fixtures/revel/app/init.go
@@ -25,7 +25,7 @@ func init() {
 		revel.ActionInvoker,           // Invoke the action.
 	}
 	bugsnag.Configure(bugsnag.Configuration{
-		Endpoint: os.Getenv("BUGSNAG_ENDPOINT"),
+		Endpoints: bugsnag.Endpoints{Notify: os.Getenv("BUGSNAG_NOTIFY_ENDPOINT"), Sessions: os.Getenv("BUGSNAG_SESSIONS_ENDPOINT")},
 	})
 	if os.Getenv("BUGSNAG_TEST_VARIANT") == "beforenotify" {
 		bugsnag.OnBeforeNotify(func(event *bugsnag.Event, config *bugsnag.Configuration) error {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -61,7 +61,7 @@ func startPanickingApp(t *testing.T,
 
 	cmd := exec.Command("go", "run", filename)
 	cmd.Env = append(os.Environ(),
-		"BUGSNAG_ENDPOINT="+testEndpoint,
+		"BUGSNAG_NOTIFY_ENDPOINT="+testEndpoint,
 		"BUGSNAG_TEST_VARIANT="+variant)
 
 	if err := cmd.Start(); err != nil {
@@ -84,7 +84,7 @@ func startPanickingApp(t *testing.T,
 func startRevelApp(t *testing.T, variant string) *simplejson.Json {
 	cmd := exec.Command("revel", "run", "github.com/bugsnag/bugsnag-go/tests/fixtures/revel")
 	cmd.Env = append(os.Environ(),
-		"BUGSNAG_ENDPOINT="+testEndpoint,
+		"BUGSNAG_NOTIFY_ENDPOINT="+testEndpoint,
 		"BUGSNAG_TEST_VARIANT="+variant)
 
 	if err := cmd.Start(); err != nil {


### PR DESCRIPTION
## Goal

In order to add session tracking to this notifier we need to be able to send the session payloads to session.bugsnag.com. This change establishes that logic along with the necessary configuration updates.

## Design

There now exists a non-exported `deliverSessions()` function that is intended to be called at regular intervals which will publish the provided sessions. It may be reasonable to make this function into a method in the future for additional testability, but it is currently left as simple as possible, i.e. no receiver.

The configuration parameter `Endpoint` has now been deprecated in favour of `Endpoints` - an analogous change to what has been made to other platforms.

## Changeset

### Added

- `Configuration.Endpoints` which relies on the `Endpoints` struct where you can specify the `Notify` and `Sessions` endpoints for on-prem users.
- `deliverSessions([]session, Configuration)` function that publishes a single session payload containing the count and when the sessions started happening.
- `Configuration.AutoCaptureSessions` (default `true`) which allows automatic session tracking to be disabled.
- BUGSNAG_SESSIONS_ENDPOINT environment variable.

### Deprecated

- `bugsnag.Configuration.Endpoint` will now log a warning if it is being used.

### Changed

- The delivery mechanism of regular payloads has been changed from a `http.Client.Post` to a `http.Client.Do` which allows for more configurability. In particular, it now attaches the `Bugsnag-` prefixed headers:
  - `Bugsnag-Api-Key`
  - `Bugsnag-Payload-Version`
  - `Bugsnag-Sent-At`
- All usages of `Endpoint` have now been switched to `Endpoints`
- The environment variable `BUGSNAG_ENDPOINT` has been deprecated in favour of `BUGSNAG_NOTIFY_ENDPOINT`

## Discussion

What exactly are the `BUGSNAG_FOO_ENDPOINT` environment variables for? They don't appear to be used outside of tests.

## Tests

Added automated tests for:

- The new headers
- The new session payloads and ensuring they get formatted as JSON appropriately when hitting a server.
- The deprecation message when `Endpoint` is being used.

Struggling to run integration tests - even on `master`.

## Review

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [ ] Final review

Leaving out the change log as this isn't going to `master`, and thus has no associated version as of yet.

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [x] Usage friction - is the proposed change in usage cumbersome or complicated?
- [x] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [x] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [x] Thoroughness of added tests and any missing edge cases
- [x] Idiomatic use of the language
