### PR TITLE
Expose a Shipper interface so that clients can create custom Shippers for specialized log processing

### DIFF
--- a/bugsnag.go
+++ b/bugsnag.go
@@ -139,6 +139,7 @@ func init() {
 		ProjectPackages:     []string{"main*"},
 		NotifyReleaseStages: nil,
 		Logger:              log.New(os.Stdout, log.Prefix(), log.Flags()),
+		Shipper:             NewHTTPShipper(),
 		PanicHandler:        defaultPanicHandler,
 		Transport:           http.DefaultTransport,
 	})

--- a/configuration.go
+++ b/configuration.go
@@ -70,7 +70,7 @@ type Configuration struct {
 	}
 	// Shipper is the expected interface for sending payload data to a backend
 	Shipper interface {
-		Deliver(p *payload) error
+		Deliver(p *Payload) error
 	}
 	// The http Transport to use, defaults to the default http Transport. This
 	// can be configured if you are in an environment like Google App Engine

--- a/configuration.go
+++ b/configuration.go
@@ -68,6 +68,10 @@ type Configuration struct {
 	Logger interface {
 		Printf(format string, v ...interface{}) // limited to the functions used
 	}
+	// Shipper is the expected interface for sending payload data to a backend
+	Shipper interface {
+		Deliver(p *payload) error
+	}
 	// The http Transport to use, defaults to the default http Transport. This
 	// can be configured if you are in an environment like Google App Engine
 	// that has stringent conditions on making http requests.
@@ -108,6 +112,9 @@ func (config *Configuration) update(other *Configuration) *Configuration {
 	}
 	if other.Logger != nil {
 		config.Logger = other.Logger
+	}
+	if other.Shipper != nil {
+		config.Shipper = other.Shipper
 	}
 	if other.NotifyReleaseStages != nil {
 		config.NotifyReleaseStages = other.NotifyReleaseStages

--- a/notifier.go
+++ b/notifier.go
@@ -50,11 +50,11 @@ func (notifier *Notifier) NotifySync(err error, synchronous bool, rawData ...int
 		config.logf("notifying bugsnag: %s", event.Message)
 		if config.notifyInReleaseStage() {
 			if synchronous {
-				return config.Shipper.Deliver(&payload{event, config})
+				return config.Shipper.Deliver(&Payload{event, config})
 			}
 			// Ensure that any errors are logged if they occur in a goroutine.
 			go func(event *Event, config *Configuration) {
-				err := config.Shipper.Deliver(&payload{event, config})
+				err := config.Shipper.Deliver(&Payload{event, config})
 				if err != nil {
 					config.logf("bugsnag.Notify: %v", err)
 				}

--- a/notifier.go
+++ b/notifier.go
@@ -50,11 +50,11 @@ func (notifier *Notifier) NotifySync(err error, synchronous bool, rawData ...int
 		config.logf("notifying bugsnag: %s", event.Message)
 		if config.notifyInReleaseStage() {
 			if synchronous {
-				return (&payload{event, config}).deliver()
+				return config.Shipper.Deliver(&payload{event, config})
 			}
 			// Ensure that any errors are logged if they occur in a goroutine.
 			go func(event *Event, config *Configuration) {
-				err := (&payload{event, config}).deliver()
+				err := config.Shipper.Deliver(&payload{event, config})
 				if err != nil {
 					config.logf("bugsnag.Notify: %v", err)
 				}

--- a/payload.go
+++ b/payload.go
@@ -1,10 +1,7 @@
 package bugsnag
 
 import (
-	"bytes"
 	"encoding/json"
-	"fmt"
-	"net/http"
 )
 
 type payload struct {
@@ -13,36 +10,6 @@ type payload struct {
 }
 
 type hash map[string]interface{}
-
-func (p *payload) deliver() error {
-
-	if len(p.APIKey) != 32 {
-		return fmt.Errorf("bugsnag/payload.deliver: invalid api key")
-	}
-
-	buf, err := json.Marshal(p)
-
-	if err != nil {
-		return fmt.Errorf("bugsnag/payload.deliver: %v", err)
-	}
-
-	client := http.Client{
-		Transport: p.Transport,
-	}
-
-	resp, err := client.Post(p.Endpoint, "application/json", bytes.NewBuffer(buf))
-
-	if err != nil {
-		return fmt.Errorf("bugsnag/payload.deliver: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("bugsnag/payload.deliver: Got HTTP %s\n", resp.Status)
-	}
-
-	return nil
-}
 
 func (p *payload) MarshalJSON() ([]byte, error) {
 

--- a/payload.go
+++ b/payload.go
@@ -4,14 +4,15 @@ import (
 	"encoding/json"
 )
 
-type payload struct {
+// Payload is a wrapper around Event and Configuration data
+type Payload struct {
 	*Event
 	*Configuration
 }
 
 type hash map[string]interface{}
 
-func (p *payload) MarshalJSON() ([]byte, error) {
+func (p *Payload) MarshalJSON() ([]byte, error) {
 
 	severityReason := hash{
 		"type": p.handledState.SeverityReason,

--- a/shipper.go
+++ b/shipper.go
@@ -1,0 +1,6 @@
+package bugsnag
+
+// Shipper is the expected interface for sending payload data to a backend
+type Shipper interface {
+	Deliver(p *payload) error
+}

--- a/shipper.go
+++ b/shipper.go
@@ -2,5 +2,5 @@ package bugsnag
 
 // Shipper is the expected interface for sending payload data to a backend
 type Shipper interface {
-	Deliver(p *payload) error
+	Deliver(p *Payload) error
 }

--- a/shipper_http.go
+++ b/shipper_http.go
@@ -1,0 +1,49 @@
+package bugsnag
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// NewHTTPShipper creates a shipper to send data over http
+func NewHTTPShipper() Shipper {
+	return &httpShipper{}
+}
+
+type httpShipper struct {
+}
+
+func (s *httpShipper) Deliver(p *payload) error {
+	if len(p.APIKey) != 32 {
+		return fmt.Errorf("bugsnag/payload.deliver: invalid api key")
+	}
+
+	buf, err := json.Marshal(p)
+
+	if err != nil {
+		return fmt.Errorf("bugsnag/payload.deliver: %v", err)
+	}
+
+	client := http.Client{
+		Transport: p.Transport,
+	}
+
+	resp, err := client.Post(
+		p.Endpoint,
+		"application/json",
+		bytes.NewBuffer(buf),
+	)
+
+	if err != nil {
+		return fmt.Errorf("bugsnag/payload.deliver: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("bugsnag/payload.deliver: Got HTTP %s\n", resp.Status)
+	}
+
+	return nil
+}

--- a/shipper_http.go
+++ b/shipper_http.go
@@ -15,7 +15,7 @@ func NewHTTPShipper() Shipper {
 type httpShipper struct {
 }
 
-func (s *httpShipper) Deliver(p *payload) error {
+func (s *httpShipper) Deliver(p *Payload) error {
 	if len(p.APIKey) != 32 {
 		return fmt.Errorf("bugsnag/payload.deliver: invalid api key")
 	}


### PR DESCRIPTION
## Goal

I would like to expose this Shipper interface so that I can create a custom backend for any logging pipeline. My specific usecase is that I would like to retain all the special processing this bugsnag client does, but would like to "ship" it to a fluent-bit backend, which handles ingesting, filtering, backpressure, routing, and eventually shipping to another appropriate backend. In this case to bugsnag.

```
bugsnag.Configure(bugsnag.Configuration{
        // Your Bugsnag project API key
        APIKey:          "YOUR API KEY HERE",
        // "fluent-bit shipper, allowing custom log processing outside of the main process."
        Shipper:         NewFluentBitShipper(),
        // more configuration options
    })
```

## Design

This seemed like the most abstract way to add such a feature, without making large sweeping changes to the codebase. This allows anyone to design any sort of backend they please, which can be as simple or as complex as they so choose.

## Changeset

### Added
`Shipper interface`
`httpShipper struct`

### Removed
method `deliver() error` for `payload struct`

### Changed
`payload struct` no longer has a `deliver() error` method
`Configuration struct` now has a default `hTTPShipper`

## Tests

Because I was not adding any new functionality, simply changing the code structure, I have currently relied on the unit tests, although these tests don't appear to have completely passed for quite some time.

## Discussion

### Alternative Approaches

Modifying configuration to take in a generic connection string eg: `tcp:localhost:7777` etc. This was not nearly as flexible as the above route.

### Outstanding Questions

The name `Shipper` was probably what I spent the most time on here... I am open to other suggestions on that name, as well as the rest of my code!

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
