### PR TITLE
[fix] Ensure fatal panics are notified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.3.2 (2018-10-05)
+
+### Bug fixes
+
+* Ensure error reports for fatal crashes gets sent
+  [#77](https://github.com/bugsnag/bugsnag-go/pull/77)
+
 ## 1.3.1 (2018-03-14)
 
 ### Bug fixes

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -15,7 +15,7 @@ import (
 )
 
 // The current version of bugsnag-go.
-const VERSION = "1.3.1"
+const VERSION = "1.3.2"
 
 var once sync.Once
 var middleware middlewareStack

--- a/panicwrap.go
+++ b/panicwrap.go
@@ -22,7 +22,7 @@ func defaultPanicHandler() {
 			defaultNotifier.Config.logf("bugsnag.handleUncaughtPanic: %v", err)
 		}
 		state := HandledState{SeverityReasonUnhandledPanic, SeverityError, true, ""}
-		Notify(toNotify, state, Configuration{Synchronous: true})
+		defaultNotifier.NotifySync(toNotify, true, state)
 	})
 
 	if err != nil {


### PR DESCRIPTION
Due to a bug in the existing `notifier.NotifySync` method, we end up
using the notifier's config value to determine whether to send
synchronously or async. In the case of a fatal panic (i.e not
`AutoNotified` or `Recover`-ed) it still got sent asynchronously.
This change ensures that it does get sent synchronously.

Tested by putting a panic immediately after the Bugsnag configuration, and seeing if it got reported.