### PR TITLE
Request data in context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ updatedeps:
 test: alldeps
 	#TODO: 2018-09-20 Not testing the 'errors' package as it relies on some very runtime-specific implementation details.
 	# The testing of 'errors' needs to be revisited
-	go test . ./gin ./martini ./negroni ./sessions ./headers ./revel
+	go test . ./gin ./martini ./negroni ./sessions ./headers
 	@go vet 2>/dev/null ; if [ $$? -eq 3 ]; then \
 		go get golang.org/x/tools/cmd/vet; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ updatedeps:
 test: alldeps
 	#TODO: 2018-09-20 Not testing the 'errors' package as it relies on some very runtime-specific implementation details.
 	# The testing of 'errors' needs to be revisited
-	go test . ./gin ./martini ./negroni ./sessions ./headers
+	go test . ./gin ./martini ./negroni ./sessions ./headers ./revel
 	@go vet 2>/dev/null ; if [ $$? -eq 3 ]; then \
 		go get golang.org/x/tools/cmd/vet; \
 	fi

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -147,11 +147,13 @@ func Handler(h http.Handler, rawData ...interface{}) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		request := r
 
-		ctx := StartSession(r.Context())
 		// Record a session if auto notify session is enabled
+		ctx := r.Context()
 		if Config.IsAutoCaptureSessions() {
-			request = r.WithContext(ctx)
+			ctx = StartSession(ctx)
 		}
+		ctx = AttachRequestData(ctx, request)
+		request = r.WithContext(ctx)
 		defer notifier.AutoNotify(ctx, request)
 		h.ServeHTTP(w, request)
 	})
@@ -169,10 +171,12 @@ func HandlerFunc(h http.HandlerFunc, rawData ...interface{}) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		request := r
 		// Record a session if auto notify session is enabled
-		if Config.IsAutoCaptureSessions() {
-			ctx := StartSession(r.Context())
-			request = r.WithContext(ctx)
+		ctx := r.Context()
+		if notifier.Config.IsAutoCaptureSessions() {
+			ctx = StartSession(ctx)
 		}
+		ctx = AttachRequestData(ctx, request)
+		request = r.WithContext(ctx)
 		defer notifier.AutoNotify(request)
 		h(w, request)
 	}

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -200,7 +200,7 @@ func init() {
 		AppVersion:          "",
 		AutoCaptureSessions: true,
 		ReleaseStage:        "",
-		ParamsFilters:       []string{"password", "secret"},
+		ParamsFilters:       []string{"password", "secret", "authorization"},
 		SourceRoot:          sourceRoot,
 		// * for app-engine
 		ProjectPackages:     []string{"main*"},

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -204,7 +204,7 @@ func init() {
 		AppVersion:          "",
 		AutoCaptureSessions: true,
 		ReleaseStage:        "",
-		ParamsFilters:       []string{"password", "secret", "authorization"},
+		ParamsFilters:       []string{"password", "secret", "authorization", "cookie"},
 		SourceRoot:          sourceRoot,
 		// * for app-engine
 		ProjectPackages:     []string{"main*"},

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -171,13 +171,13 @@ func HandlerFunc(h http.HandlerFunc, rawData ...interface{}) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		request := r
 		// Record a session if auto notify session is enabled
-		ctx := r.Context()
+		ctx := request.Context()
 		if notifier.Config.IsAutoCaptureSessions() {
 			ctx = StartSession(ctx)
 		}
 		ctx = AttachRequestData(ctx, request)
-		request = r.WithContext(ctx)
-		defer notifier.AutoNotify(request)
+		request = request.WithContext(ctx)
+		defer notifier.AutoNotify(ctx)
 		h(w, request)
 	}
 }

--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -182,6 +182,15 @@ func TestHandler(t *testing.T) {
 		Exceptions:     []exceptionJSON{{ErrorClass: "runtime.plainError", Message: "send on closed channel"}},
 	})
 	event := getIndex(json, "events", 0)
+	if got, exp := getString(event, "request.headers.Accept-Encoding"), "gzip"; got != exp {
+		t.Errorf("expected Accept-Encoding header to be '%s' but was '%s'", exp, got)
+	}
+	if got, exp := getString(event, "request.httpMethod"), "GET"; got != exp {
+		t.Errorf("expected HTTP method to be '%s' but was '%s'", exp, got)
+	}
+	if got, exp := getString(event, "request.url"), "/ok?foo=bar"; got != exp {
+		t.Errorf("expected request URL to be '%s' but was '%s'", exp, got)
+	}
 	assertValidSession(t, event, unhandled)
 	for k, exp := range map[string]string{
 		"metaData.request.httpMethod": "GET",

--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -123,6 +123,7 @@ func TestNotify(t *testing.T) {
 		Severity:       "warning",
 		SeverityReason: &severityReasonJSON{Type: SeverityReasonHandledError},
 		Unhandled:      false,
+		Request:        &RequestJSON{},
 		User:           &User{Id: "123", Name: "Conrad", Email: "me@cirw.in"},
 		Exceptions:     []exceptionJSON{{ErrorClass: "*errors.errorString", Message: "hello world"}},
 	})
@@ -142,6 +143,88 @@ func TestNotify(t *testing.T) {
 	exception := getIndex(event, "exceptions", 0)
 	checkFrame(t, getIndex(exception, "stacktrace", 0), stackFrame{File: "bugsnag_test.go", Method: "TestNotify", InProject: true})
 	checkFrame(t, getIndex(exception, "stacktrace", 1), stackFrame{File: "testing/testing.go", Method: "tRunner", InProject: false})
+}
+
+func TestHandlerFunc(t *testing.T) {
+	eventserver, reports := setup()
+	defer eventserver.Close()
+	Configure(generateSampleConfig(eventserver.URL))
+
+	t.Run("unhandled", func(st *testing.T) {
+		ts := httptest.NewServer(HandlerFunc(crashyHandler))
+		defer ts.Close()
+
+		http.Get(ts.URL + "/unhandled")
+
+		json, _ := simplejson.NewJson(<-reports)
+		assertPayload(t, json, eventJSON{
+			App:            &appJSON{ReleaseStage: "test", Type: "foo", Version: "1.2.3"},
+			Context:        "/unhandled",
+			Device:         &deviceJSON{Hostname: "web1"},
+			GroupingHash:   "",
+			Session:        &sessionJSON{Events: eventCountsJSON{Handled: 0, Unhandled: 1}},
+			Severity:       "error",
+			SeverityReason: &severityReasonJSON{Type: SeverityReasonHandledPanic},
+			Unhandled:      true,
+			Request: &RequestJSON{
+				Headers:    map[string]string{"Accept-Encoding": "gzip"},
+				HTTPMethod: "GET",
+				URL:        ts.URL + "/unhandled",
+			},
+			User:       &User{Id: "127.0.0.1", Name: "", Email: ""},
+			Exceptions: []exceptionJSON{{ErrorClass: "runtime.plainError", Message: "send on closed channel"}},
+		})
+		event := getIndex(json, "events", 0)
+		if got, exp := getString(event, "request.headers.Accept-Encoding"), "gzip"; got != exp {
+			st.Errorf("expected Accept-Encoding header to be '%s' but was '%s'", exp, got)
+		}
+		if got, exp := getString(event, "request.httpMethod"), "GET"; got != exp {
+			st.Errorf("expected HTTP method to be '%s' but was '%s'", exp, got)
+		}
+		if got, exp := getString(event, "request.url"), "/unhandled"; !strings.Contains(got, exp) {
+			st.Errorf("expected request URL to contain '%s' but was '%s'", exp, got)
+		}
+		assertValidSession(st, event, unhandled)
+	})
+
+	t.Run("handled", func(st *testing.T) {
+		ts := httptest.NewServer(HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Notify(fmt.Errorf("oopsie"), r.Context())
+		}))
+		defer ts.Close()
+
+		http.Get(ts.URL + "/handled")
+
+		json, _ := simplejson.NewJson(<-reports)
+		assertPayload(t, json, eventJSON{
+			App:            &appJSON{ReleaseStage: "test", Type: "foo", Version: "1.2.3"},
+			Context:        "/handled",
+			Device:         &deviceJSON{Hostname: "web1"},
+			GroupingHash:   "",
+			Session:        &sessionJSON{Events: eventCountsJSON{Handled: 1, Unhandled: 0}},
+			Severity:       "warning",
+			SeverityReason: &severityReasonJSON{Type: SeverityReasonHandledError},
+			Unhandled:      false,
+			Request: &RequestJSON{
+				Headers:    map[string]string{"Accept-Encoding": "gzip"},
+				HTTPMethod: "GET",
+				URL:        ts.URL + "/handled",
+			},
+			User:       &User{Id: "127.0.0.1", Name: "", Email: ""},
+			Exceptions: []exceptionJSON{{ErrorClass: "*errors.errorString", Message: "oopsie"}},
+		})
+		event := getIndex(json, "events", 0)
+		if got, exp := getString(event, "request.headers.Accept-Encoding"), "gzip"; got != exp {
+			st.Errorf("expected Accept-Encoding header to be '%s' but was '%s'", exp, got)
+		}
+		if got, exp := getString(event, "request.httpMethod"), "GET"; got != exp {
+			st.Errorf("expected HTTP method to be '%s' but was '%s'", exp, got)
+		}
+		if got, exp := getString(event, "request.url"), "/handled"; !strings.Contains(got, exp) {
+			st.Errorf("expected request URL to contain '%s' but was '%s'", exp, got)
+		}
+		assertValidSession(st, event, handled)
+	})
 }
 
 func TestHandler(t *testing.T) {
@@ -179,7 +262,12 @@ func TestHandler(t *testing.T) {
 		SeverityReason: &severityReasonJSON{Type: SeverityReasonHandledPanic},
 		Unhandled:      true,
 		User:           &User{Id: "127.0.0.1", Name: "", Email: ""},
-		Exceptions:     []exceptionJSON{{ErrorClass: "runtime.plainError", Message: "send on closed channel"}},
+		Request: &RequestJSON{
+			Headers:    map[string]string{"Accept-Encoding": "gzip"},
+			HTTPMethod: "GET",
+			URL:        "http://" + l.Addr().String() + "/ok?foo=bar",
+		},
+		Exceptions: []exceptionJSON{{ErrorClass: "runtime.plainError", Message: "send on closed channel"}},
 	})
 	event := getIndex(json, "events", 0)
 	if got, exp := getString(event, "request.headers.Accept-Encoding"), "gzip"; got != exp {
@@ -188,25 +276,12 @@ func TestHandler(t *testing.T) {
 	if got, exp := getString(event, "request.httpMethod"), "GET"; got != exp {
 		t.Errorf("expected HTTP method to be '%s' but was '%s'", exp, got)
 	}
-	if got, exp := getString(event, "request.url"), "/ok?foo=bar"; got != exp {
+	if got, exp := getString(event, "request.url"), "/ok?foo=bar"; !strings.Contains(got, exp) {
 		t.Errorf("expected request URL to be '%s' but was '%s'", exp, got)
 	}
 	assertValidSession(t, event, unhandled)
-	for k, exp := range map[string]string{
-		"metaData.request.httpMethod": "GET",
-		"metaData.request.url":        "http://" + l.Addr().String() + "/ok?foo=bar",
-	} {
-		if got := getString(event, k); got != exp {
-			t.Errorf("Expected %s to be '%s' but was '%s'", k, exp, got)
-		}
-	}
-	for k, exp := range map[string]string{
-		"metaData.request.params.foo":              "bar",
-		"metaData.request.headers.Accept-Encoding": "gzip",
-	} {
-		if got := getFirstString(event, k); got != exp {
-			t.Errorf("Expected %s to be '%s' but was '%s'", k, exp, got)
-		}
+	if got, exp := getFirstString(event, "metaData.request.params.foo"), "bar"; got != exp {
+		t.Errorf("Expected metadata params 'foo' to be '%s' but was '%s'", exp, got)
 	}
 
 	exception := getIndex(event, "exceptions", 0)
@@ -254,6 +329,7 @@ func TestAutoNotify(t *testing.T) {
 		SeverityReason: &severityReasonJSON{Type: SeverityReasonHandledPanic},
 		Unhandled:      true,
 		User:           &User{},
+		Request:        &RequestJSON{},
 		Exceptions:     []exceptionJSON{{ErrorClass: "*errors.errorString", Message: "eggs"}},
 	})
 }
@@ -291,6 +367,7 @@ func TestRecover(t *testing.T) {
 		Severity:       "warning",
 		SeverityReason: &severityReasonJSON{Type: SeverityReasonHandledPanic},
 		Unhandled:      false,
+		Request:        &RequestJSON{},
 		User:           &User{},
 		Exceptions:     []exceptionJSON{{ErrorClass: "*errors.errorString", Message: "ham"}},
 	})
@@ -333,6 +410,7 @@ func TestRecoverCustomHandledState(t *testing.T) {
 		Severity:       "error",
 		SeverityReason: &severityReasonJSON{Type: SeverityReasonHandledPanic},
 		Unhandled:      true,
+		Request:        &RequestJSON{},
 		User:           &User{},
 		Exceptions:     []exceptionJSON{{ErrorClass: "*errors.errorString", Message: "at the disco?"}},
 	})
@@ -359,6 +437,7 @@ func TestSeverityReasonNotifyCallback(t *testing.T) {
 		Severity:       "info",
 		SeverityReason: &severityReasonJSON{Type: SeverityReasonCallbackSpecified},
 		Unhandled:      false,
+		Request:        &RequestJSON{},
 		User:           &User{},
 		Exceptions:     []exceptionJSON{{ErrorClass: "*errors.errorString", Message: "hello world"}},
 	})
@@ -473,6 +552,10 @@ func assertPayload(t *testing.T, report *simplejson.Json, exp eventJSON) {
 
 		{prop: "severity", exp: exp.Severity, got: getString(event, "severity")},
 		{prop: "severity reason type", exp: string(exp.SeverityReason.Type), got: getString(event, "severityReason.type")},
+
+		{prop: "request header 'Accept-Encoding'", exp: string(exp.Request.Headers["Accept-Encoding"]), got: getString(event, "request.headers.Accept-Encoding")},
+		{prop: "request HTTP method", exp: string(exp.Request.HTTPMethod), got: getString(event, "request.httpMethod")},
+		{prop: "request URL", exp: string(exp.Request.URL), got: getString(event, "request.url")},
 	} {
 		if tc.got != tc.exp {
 			t.Errorf("Wrong %s: expected '%v' but got '%v'", tc.prop, tc.exp, tc.got)

--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -129,7 +129,7 @@ func TestNotify(t *testing.T) {
 	assertValidSession(t, event, handled)
 
 	for k, exp := range map[string]string{
-		"metaData.test.password":        "[REDACTED]",
+		"metaData.test.password":        "[FILTERED]",
 		"metaData.test.value":           "able",
 		"metaData.test.broken":          "[complex128]",
 		"metaData.test.recurse.Recurse": "[RECURSION]",

--- a/configuration.go
+++ b/configuration.go
@@ -79,7 +79,7 @@ type Configuration struct {
 	// build.
 	SourceRoot string
 
-	// Any meta-data that matches these filters will be marked as [REDACTED]
+	// Any meta-data that matches these filters will be marked as [FILTERED]
 	// before sending a Notification to Bugsnag. It defaults to
 	// []string{"password", "secret"} so that request parameters like password,
 	// password_confirmation and auth_secret will not be sent to Bugsnag.

--- a/event.go
+++ b/event.go
@@ -101,6 +101,8 @@ type Event struct {
 	MetaData MetaData
 	// Ctx is the context of the session the event occurred in. This allows Bugsnag to associate the event with the session.
 	Ctx context.Context
+	// Request is the request information that populates the Request tab in the dashboard.
+	Request *RequestJSON
 	// The reason for the severity and original value
 	handledState HandledState
 }
@@ -144,6 +146,7 @@ func newEvent(rawData []interface{}, notifier *Notifier) (*Event, *Configuration
 
 		case context.Context:
 			event.Ctx = datum
+			event.Request = extractRequestInfo(datum)
 
 		case Configuration:
 			config = config.merge(&datum)

--- a/event_test.go
+++ b/event_test.go
@@ -1,0 +1,37 @@
+package bugsnag
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestPopulateEvent(t *testing.T) {
+	event := new(Event)
+	contexts := make(chan context.Context, 1)
+	reqs := make(chan *http.Request, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contexts <- AttachRequestData(r.Context(), r)
+		reqs <- r
+	}))
+	defer ts.Close()
+
+	http.Get(ts.URL + "/serenity?q=abcdef")
+
+	ctx, req := <-contexts, <-reqs
+	populateEventWithContext(ctx, event)
+
+	for _, tc := range []struct{ e, c interface{} }{
+		{e: event.Ctx, c: ctx},
+		{e: event.Request, c: extractRequestInfoFromReq(req)},
+		{e: event.Context, c: req.URL.Path},
+		{e: event.User.Id, c: req.RemoteAddr[:strings.LastIndex(req.RemoteAddr, ":")]},
+	} {
+		if !reflect.DeepEqual(tc.e, tc.c) {
+			t.Errorf("Expected '%+v' and '%+v' to be equal", tc.e, tc.c)
+		}
+	}
+}

--- a/gin/bugsnaggin.go
+++ b/gin/bugsnaggin.go
@@ -31,6 +31,7 @@ func AutoNotify(rawData ...interface{}) gin.HandlerFunc {
 		r := c.Copy().Request
 		ctx := r.Context()
 		ctx = bugsnag.StartSession(ctx)
+		ctx = bugsnag.AttachRequestData(ctx, r)
 		c.Request = r.WithContext(ctx)
 
 		// create a notifier that has the current request bound to it

--- a/gin/gin_test.go
+++ b/gin/gin_test.go
@@ -61,6 +61,14 @@ func TestGin(t *testing.T) {
 					"severity":"error",
 					"severityReason":{ "type":"unhandledErrorMiddleware" },
 					"unhandled":true,
+					"request": {
+						"url": "/unhandled",
+						"httpMethod": "GET",
+						"referer": "",
+						"headers": {
+							"Accept-Encoding": "gzip"
+						}
+					},
 					"user":{ "id": "%s" }
 				}
 			],
@@ -100,6 +108,14 @@ func TestGin(t *testing.T) {
 					"severity":"warning",
 					"severityReason":{ "type":"handledError" },
 					"unhandled":false,
+					"request": {
+						"url": "/handled",
+						"httpMethod": "GET",
+						"referer": "",
+						"headers": {
+							"Accept-Encoding": "gzip"
+						}
+					},
 					"user":{ "id": "%s" }
 				}
 			],

--- a/gin/gin_test.go
+++ b/gin/gin_test.go
@@ -54,15 +54,12 @@ func TestGin(t *testing.T) {
 							"stacktrace":[]
 						}
 					],
-					"metaData":{
-						"request":{ "httpMethod":"GET", "url":"http://localhost:9079/unhandled" }
-					},
 					"payloadVersion":"4",
 					"severity":"error",
 					"severityReason":{ "type":"unhandledErrorMiddleware" },
 					"unhandled":true,
 					"request": {
-						"url": "/unhandled",
+						"url": "http://localhost:9079/unhandled",
 						"httpMethod": "GET",
 						"referer": "",
 						"headers": {
@@ -109,7 +106,7 @@ func TestGin(t *testing.T) {
 					"severityReason":{ "type":"handledError" },
 					"unhandled":false,
 					"request": {
-						"url": "/handled",
+						"url": "http://localhost:9079/handled",
 						"httpMethod": "GET",
 						"referer": "",
 						"headers": {

--- a/martini/martini_test.go
+++ b/martini/martini_test.go
@@ -1,7 +1,6 @@
 package bugsnagmartini_test
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -15,8 +14,8 @@ import (
 	"github.com/go-martini/martini"
 )
 
-func performHandledError(notifier *bugsnag.Notifier) {
-	ctx := bugsnag.StartSession(context.Background())
+func performHandledError(notifier *bugsnag.Notifier, r *http.Request) {
+	ctx := r.Context()
 	notifier.Notify(ctx, fmt.Errorf("Ooopsie"), bugsnag.User{Id: "987zyx"})
 }
 
@@ -69,16 +68,13 @@ func TestMartini(t *testing.T) {
 							"stacktrace":[]
 						}
 					],
-					"metaData":{
-						"request":{ "httpMethod":"GET", "url":"http://localhost:9077/unhandled" }
-					},
 					"payloadVersion":"4",
 					"severity":"error",
 					"severityReason":{ "type":"unhandledErrorMiddleware" },
 					"unhandled":true,
 					"request": {
 						"httpMethod": "GET",
-						"url": "/unhandled",
+						"url": "http://localhost:9077/unhandled",
 						"headers": {
 							"Accept-Encoding": "gzip"
 						}
@@ -118,12 +114,16 @@ func TestMartini(t *testing.T) {
 							"stacktrace":[]
 						}
 					],
-					"metaData":{
-						"request":{ "httpMethod":"GET", "url":"http://localhost:9077/handled" }
-					},
 					"payloadVersion":"4",
 					"severity":"error",
 					"severityReason":{ "type":"unhandledErrorMiddleware" },
+					"request": {
+						"url": "http://localhost:9077/handled",
+						"httpMethod": "GET",
+						"headers": {
+							"Accept-Encoding": "gzip"
+						}
+					},
 					"unhandled":true,
 					"user":{ "id": "%s" }
 				}

--- a/martini/martini_test.go
+++ b/martini/martini_test.go
@@ -28,15 +28,17 @@ func TestMartini(t *testing.T) {
 	ts, reports := Setup()
 	defer ts.Close()
 
-	m := martini.Classic()
-
-	userID := "1234abcd"
-	m.Use(martini.Recovery())
 	config := bugsnag.Configuration{
 		APIKey:    TestAPIKey,
 		Endpoints: bugsnag.Endpoints{Notify: ts.URL, Sessions: ts.URL + "/sessions"},
 	}
 	bugsnag.Configure(config)
+
+	m := martini.Classic()
+
+	userID := "1234abcd"
+
+	m.Use(martini.Recovery())
 	m.Use(bugsnagmartini.AutoNotify(bugsnag.User{Id: userID}))
 
 	m.Get("/unhandled", performUnhandledCrash)
@@ -74,6 +76,13 @@ func TestMartini(t *testing.T) {
 					"severity":"error",
 					"severityReason":{ "type":"unhandledErrorMiddleware" },
 					"unhandled":true,
+					"request": {
+						"httpMethod": "GET",
+						"url": "/unhandled",
+						"headers": {
+							"Accept-Encoding": "gzip"
+						}
+					},
 					"user":{ "id": "%s" }
 				}
 			],

--- a/metadata.go
+++ b/metadata.go
@@ -136,7 +136,7 @@ func (s sanitizer) sanitizeMap(v reflect.Value) interface{} {
 		newKey := fmt.Sprintf("%v", key.Interface())
 
 		if s.shouldRedact(newKey) {
-			val = "[REDACTED]"
+			val = "[FILTERED]"
 		}
 
 		ret[newKey] = val
@@ -165,7 +165,7 @@ func (s sanitizer) sanitizeStruct(v reflect.Value, t reflect.Type) interface{} {
 		}
 
 		if s.shouldRedact(name) {
-			ret[name] = "[REDACTED]"
+			ret[name] = "[FILTERED]"
 		} else {
 			sanitized := s.Sanitize(val.Interface())
 			if str, ok := sanitized.(string); ok {

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -143,9 +143,9 @@ func TestMetaDataSanitize(t *testing.T) {
 			"string":   "string",
 			"unsafe":   "[unsafe.Pointer]",
 			"func":     "[func()]",
-			"password": "[REDACTED]",
+			"password": "[FILTERED]",
 			"array": []interface{}{map[string]interface{}{
-				"creditcard": "[REDACTED]",
+				"creditcard": "[FILTERED]",
 				"broken": map[string]interface{}{
 					"Me":   "[RECURSION]",
 					"Data": "ohai",
@@ -161,7 +161,7 @@ func TestMetaDataSanitize(t *testing.T) {
 				"Plan": map[string]interface{}{
 					"Premium": false,
 				},
-				"Password":        "[REDACTED]",
+				"Password":        "[FILTERED]",
 				"email":           "example@example.com",
 				"not_empty_email": "not_empty_email@example.com",
 			},

--- a/middleware.go
+++ b/middleware.go
@@ -2,7 +2,6 @@ package bugsnag
 
 import (
 	"net/http"
-	"strings"
 )
 
 type (
@@ -64,34 +63,11 @@ func catchMiddlewarePanic(event *Event, config *Configuration, next func() error
 func httpRequestMiddleware(event *Event, config *Configuration) error {
 	for _, datum := range event.RawData {
 		if request, ok := datum.(*http.Request); ok {
-			proto := "http://"
-			if request.TLS != nil {
-				proto = "https://"
-			}
-
 			event.MetaData.Update(MetaData{
 				"request": {
-					"clientIp":   request.RemoteAddr,
-					"httpMethod": request.Method,
-					"url":        proto + request.Host + request.RequestURI,
-					"params":     request.URL.Query(),
-					"headers":    request.Header,
+					"params": request.URL.Query(),
 				},
 			})
-
-			// Default context to Path
-			if event.Context == "" {
-				event.Context = request.URL.Path
-			}
-
-			// Default user.id to IP so that users-affected works.
-			if event.User == nil {
-				ip := request.RemoteAddr
-				if idx := strings.LastIndex(ip, ":"); idx != -1 {
-					ip = ip[:idx]
-				}
-				event.User = &User{Id: ip}
-			}
 		}
 	}
 	return nil

--- a/negroni/bugsnagnegroni.go
+++ b/negroni/bugsnagnegroni.go
@@ -31,6 +31,7 @@ func (h *handler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.H
 	// Record a session if auto capture sessions is enabled
 	if bugsnag.Config.IsAutoCaptureSessions() {
 		ctx := bugsnag.StartSession(r.Context())
+		ctx = bugsnag.AttachRequestData(ctx, r)
 		request = r.WithContext(ctx)
 		notifier := bugsnag.New(append(h.rawData, request)...)
 		notifier.FlushSessionsOnRepanic(false)

--- a/negroni/bugsnagnegroni.go
+++ b/negroni/bugsnagnegroni.go
@@ -27,20 +27,15 @@ func AutoNotify(rawData ...interface{}) negroni.Handler {
 }
 
 func (h *handler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	request := r
 	// Record a session if auto capture sessions is enabled
+	ctx := bugsnag.AttachRequestData(r.Context(), r)
 	if bugsnag.Config.IsAutoCaptureSessions() {
-		ctx := bugsnag.StartSession(r.Context())
-		ctx = bugsnag.AttachRequestData(ctx, r)
-		request = r.WithContext(ctx)
-		notifier := bugsnag.New(append(h.rawData, request)...)
-		notifier.FlushSessionsOnRepanic(false)
-		defer notifier.AutoNotify(ctx, request)
-	} else {
-		notifier := bugsnag.New(append(h.rawData, request)...)
-		notifier.FlushSessionsOnRepanic(false)
-		defer notifier.AutoNotify(request)
+		ctx = bugsnag.StartSession(ctx)
 	}
+	request := r.WithContext(ctx)
+	notifier := bugsnag.New(h.rawData...)
+	notifier.FlushSessionsOnRepanic(false)
+	defer notifier.AutoNotify(ctx)
 	next(rw, request)
 
 }

--- a/negroni/negroni_test.go
+++ b/negroni/negroni_test.go
@@ -62,6 +62,14 @@ func TestNegroni(t *testing.T) {
 					"severity":"error",
 					"severityReason":{ "type":"unhandledErrorMiddleware" },
 					"unhandled":true,
+					"request": {
+						"url": "/unhandled",
+						"httpMethod": "GET",
+						"referer": "",
+						"headers": {
+							"Accept-Encoding": "gzip"
+						}
+					},
 					"user":{ "id": "%s" }
 				}
 			],

--- a/negroni/negroni_test.go
+++ b/negroni/negroni_test.go
@@ -55,15 +55,12 @@ func TestNegroni(t *testing.T) {
 							"stacktrace":[]
 						}
 					],
-					"metaData":{
-						"request":{ "httpMethod":"GET", "url":"http://localhost:9078/unhandled" }
-					},
 					"payloadVersion":"4",
 					"severity":"error",
 					"severityReason":{ "type":"unhandledErrorMiddleware" },
 					"unhandled":true,
 					"request": {
-						"url": "/unhandled",
+						"url": "http://localhost:9078/unhandled",
 						"httpMethod": "GET",
 						"referer": "",
 						"headers": {

--- a/panicwrap_test.go
+++ b/panicwrap_test.go
@@ -35,6 +35,7 @@ func TestPanicHandlerHandledPanic(t *testing.T) {
 		Severity:       "error",
 		SeverityReason: &severityReasonJSON{Type: SeverityReasonHandledPanic},
 		Unhandled:      true,
+		Request:        &RequestJSON{},
 		User:           &User{},
 		Exceptions:     []exceptionJSON{{ErrorClass: "*errors.errorString", Message: "ruh roh"}},
 	})
@@ -71,6 +72,7 @@ func TestPanicHandlerUnhandledPanic(t *testing.T) {
 		Severity:       "error",
 		SeverityReason: &severityReasonJSON{Type: SeverityReasonUnhandledPanic},
 		Unhandled:      true,
+		Request:        &RequestJSON{},
 		User:           &User{},
 		Exceptions:     []exceptionJSON{{ErrorClass: "panic", Message: "ruh roh"}},
 	})

--- a/payload.go
+++ b/payload.go
@@ -65,6 +65,7 @@ func (p *payload) MarshalJSON() ([]byte, error) {
 				},
 				Context: p.Context,
 				Device:  &deviceJSON{Hostname: p.Hostname},
+				Request: extractRequestInfo(p.Ctx),
 				Exceptions: []exceptionJSON{
 					exceptionJSON{
 						ErrorClass: p.ErrorClass,

--- a/payload.go
+++ b/payload.go
@@ -65,7 +65,7 @@ func (p *payload) MarshalJSON() ([]byte, error) {
 				},
 				Context: p.Context,
 				Device:  &deviceJSON{Hostname: p.Hostname},
-				Request: extractRequestInfo(p.Ctx),
+				Request: p.Request,
 				Exceptions: []exceptionJSON{
 					exceptionJSON{
 						ErrorClass: p.ErrorClass,

--- a/report.go
+++ b/report.go
@@ -65,7 +65,6 @@ type deviceJSON struct {
 	Hostname string `json:"hostname,omitempty"`
 }
 
-//TODO: ensure that multiple values are allowed for the headers
 type requestJSON struct {
 	ClientIP   string            `json:"clientIp"`
 	Headers    map[string]string `json:"headers"`

--- a/report.go
+++ b/report.go
@@ -22,7 +22,7 @@ type eventJSON struct {
 	App            *appJSON            `json:"app"`
 	Context        string              `json:"context,omitempty"`
 	Device         *deviceJSON         `json:"device,omitempty"`
-	Request        *requestJSON        `json:"request,omitempty"`
+	Request        *RequestJSON        `json:"request,omitempty"`
 	Exceptions     []exceptionJSON     `json:"exceptions"`
 	GroupingHash   string              `json:"groupingHash,omitempty"`
 	Metadata       interface{}         `json:"metaData"`
@@ -65,7 +65,8 @@ type deviceJSON struct {
 	Hostname string `json:"hostname,omitempty"`
 }
 
-type requestJSON struct {
+// RequestJSON is the request information that populates the Request tab in the dashboard.
+type RequestJSON struct {
 	ClientIP   string            `json:"clientIp"`
 	Headers    map[string]string `json:"headers"`
 	HTTPMethod string            `json:"httpMethod"`

--- a/report.go
+++ b/report.go
@@ -67,9 +67,9 @@ type deviceJSON struct {
 
 // RequestJSON is the request information that populates the Request tab in the dashboard.
 type RequestJSON struct {
-	ClientIP   string            `json:"clientIp"`
-	Headers    map[string]string `json:"headers"`
-	HTTPMethod string            `json:"httpMethod"`
-	URL        string            `json:"url"`
-	Referer    string            `json:"referer"`
+	ClientIP   string            `json:"clientIp,omitempty"`
+	Headers    map[string]string `json:"headers,omitempty"`
+	HTTPMethod string            `json:"httpMethod,omitempty"`
+	URL        string            `json:"url,omitempty"`
+	Referer    string            `json:"referer,omitempty"`
 }

--- a/report.go
+++ b/report.go
@@ -22,6 +22,7 @@ type eventJSON struct {
 	App            *appJSON            `json:"app"`
 	Context        string              `json:"context,omitempty"`
 	Device         *deviceJSON         `json:"device,omitempty"`
+	Request        *requestJSON        `json:"request,omitempty"`
 	Exceptions     []exceptionJSON     `json:"exceptions"`
 	GroupingHash   string              `json:"groupingHash,omitempty"`
 	Metadata       interface{}         `json:"metaData"`
@@ -62,4 +63,13 @@ type severityReasonJSON struct {
 
 type deviceJSON struct {
 	Hostname string `json:"hostname,omitempty"`
+}
+
+//TODO: ensure that multiple values are allowed for the headers
+type requestJSON struct {
+	ClientIP   string            `json:"clientIp"`
+	Headers    map[string]string `json:"headers"`
+	HTTPMethod string            `json:"httpMethod"`
+	URL        string            `json:"url"`
+	Referer    string            `json:"referer"`
 }

--- a/request_extractor.go
+++ b/request_extractor.go
@@ -21,7 +21,7 @@ func AttachRequestData(ctx context.Context, r *http.Request) context.Context {
 // automatically attaches to the context when using any of the supported
 // frameworks or bugsnag.HandlerFunc or bugsnag.Handler, and returns sub-object
 // supported by the notify API.
-func extractRequestInfo(ctx context.Context) *requestJSON {
+func extractRequestInfo(ctx context.Context) *RequestJSON {
 	if req := getRequestIfPresent(ctx); req != nil {
 		return extractRequestInfoFromReq(req)
 	}
@@ -31,8 +31,8 @@ func extractRequestInfo(ctx context.Context) *requestJSON {
 // extractRequestInfoFromReq extracts the request information the notify API
 // understands from the given HTTP request. Returns the sub-object supported by
 // the notify API.
-func extractRequestInfoFromReq(req *http.Request) *requestJSON {
-	return &requestJSON{
+func extractRequestInfoFromReq(req *http.Request) *RequestJSON {
+	return &RequestJSON{
 		ClientIP:   req.RemoteAddr,
 		HTTPMethod: req.Method,
 		URL:        req.RequestURI,

--- a/request_extractor.go
+++ b/request_extractor.go
@@ -61,7 +61,7 @@ func parseRequestHeaders(header map[string][]string) map[string]string {
 	for k, v := range header {
 		// Headers can have multiple values, in which case we report them as csv
 		if contains(Config.ParamsFilters, k) {
-			headers[k] = "[REDACTED]"
+			headers[k] = "[FILTERED]"
 		} else {
 			headers[k] = strings.Join(v, ",")
 		}

--- a/request_extractor.go
+++ b/request_extractor.go
@@ -10,6 +10,13 @@ const requestContextKey requestKey = 0
 
 type requestKey int
 
+// AttachRequestData returns a child of the given context with the request
+// object attached for later extraction by the notifier in order to
+// automatically record request data
+func AttachRequestData(ctx context.Context, r *http.Request) context.Context {
+	return context.WithValue(ctx, requestContextKey, r)
+}
+
 // extractRequestInfo looks for the request object that the notifier
 // automatically attaches to the context when using any of the supported
 // frameworks or bugsnag.HandlerFunc or bugsnag.Handler, and returns sub-object
@@ -34,13 +41,6 @@ func extractRequestInfoFromReq(req *http.Request) *requestJSON {
 	}
 }
 
-// attachRequestData returns a child of the given context with the request
-// object attached for later extraction by the notifier in order to
-// automatically record request data
-func attachRequestData(ctx context.Context, r *http.Request) context.Context {
-	return context.WithValue(ctx, requestContextKey, r)
-}
-
 func parseRequestHeaders(header map[string][]string) map[string]string {
 	headers := make(map[string]string)
 	for k, v := range header {
@@ -62,6 +62,7 @@ func contains(slice []string, e string) bool {
 	}
 	return false
 }
+
 func getRequestIfPresent(ctx context.Context) *http.Request {
 	if ctx == nil {
 		return nil

--- a/request_extractor.go
+++ b/request_extractor.go
@@ -1,0 +1,74 @@
+package bugsnag
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+const requestContextKey requestKey = 0
+
+type requestKey int
+
+// extractRequestInfo looks for the request object that the notifier
+// automatically attaches to the context when using any of the supported
+// frameworks or bugsnag.HandlerFunc or bugsnag.Handler, and returns sub-object
+// supported by the notify API.
+func extractRequestInfo(ctx context.Context) *requestJSON {
+	if req := getRequestIfPresent(ctx); req != nil {
+		return extractRequestInfoFromReq(req)
+	}
+	return nil
+}
+
+// extractRequestInfoFromReq extracts the request information the notify API
+// understands from the given HTTP request. Returns the sub-object supported by
+// the notify API.
+func extractRequestInfoFromReq(req *http.Request) *requestJSON {
+	return &requestJSON{
+		ClientIP:   req.RemoteAddr,
+		HTTPMethod: req.Method,
+		URL:        req.RequestURI,
+		Referer:    req.Referer(),
+		Headers:    parseRequestHeaders(req.Header),
+	}
+}
+
+// attachRequestData returns a child of the given context with the request
+// object attached for later extraction by the notifier in order to
+// automatically record request data
+func attachRequestData(ctx context.Context, r *http.Request) context.Context {
+	return context.WithValue(ctx, requestContextKey, r)
+}
+
+func parseRequestHeaders(header map[string][]string) map[string]string {
+	headers := make(map[string]string)
+	for k, v := range header {
+		// Headers can have multiple values, in which case we report them as csv
+		if contains(Config.ParamsFilters, k) {
+			headers[k] = "[REDACTED]"
+		} else {
+			headers[k] = strings.Join(v, ",")
+		}
+	}
+	return headers
+}
+
+func contains(slice []string, e string) bool {
+	for _, s := range slice {
+		if s == e {
+			return true
+		}
+	}
+	return false
+}
+func getRequestIfPresent(ctx context.Context) *http.Request {
+	if ctx == nil {
+		return nil
+	}
+	val := ctx.Value(requestContextKey)
+	if val == nil {
+		return nil
+	}
+	return val.(*http.Request)
+}

--- a/request_extractor_test.go
+++ b/request_extractor_test.go
@@ -13,7 +13,7 @@ func TestRequestInformationGetsExtracted(t *testing.T) {
 	contexts := make(chan context.Context, 1)
 	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		ctx = attachRequestData(ctx, r)
+		ctx = AttachRequestData(ctx, r)
 		contexts <- ctx
 	})
 	ts := httptest.NewServer(hf)

--- a/request_extractor_test.go
+++ b/request_extractor_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 )
 
 func TestRequestInformationGetsExtracted(t *testing.T) {
-	sessionTracker = &testSessionTracker{}
 	contexts := make(chan context.Context, 1)
 	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
@@ -38,6 +38,23 @@ func TestRequestInformationGetsExtracted(t *testing.T) {
 	}
 	if got, exp := reqJSON.Headers["User-Agent"], "Go-http-client"; !strings.Contains(got, exp) {
 		t.Errorf("expected user agent to contain '%s' but was '%s'", exp, got)
+	}
+}
+
+func TestExtractingRequestJSON(t *testing.T) {
+	json := &RequestJSON{
+		ClientIP: "8.8.8.8",
+		Headers: map[string]string{
+			"most-goals": "Peter Crouch",
+		},
+		HTTPMethod: "GET",
+		URL:        "/my-name-is-url",
+		Referer:    "twitter",
+	}
+	ctx := AttachRequestJSONData(context.Background(), json)
+	reqJSON := extractRequestInfo(ctx)
+	if !reflect.DeepEqual(reqJSON, json) {
+		t.Errorf("Expected JSON object '%+v' to be identical to '%+v'", reqJSON, json)
 	}
 }
 

--- a/request_extractor_test.go
+++ b/request_extractor_test.go
@@ -1,0 +1,65 @@
+package bugsnag
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRequestInformationGetsExtracted(t *testing.T) {
+	sessionTracker = &testSessionTracker{}
+	contexts := make(chan context.Context, 1)
+	hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		ctx = attachRequestData(ctx, r)
+		contexts <- ctx
+	})
+	ts := httptest.NewServer(hf)
+	defer ts.Close()
+	http.Get(ts.URL + "/1234abcd")
+
+	reqJSON := extractRequestInfo(<-contexts)
+	if reqJSON.ClientIP == "" {
+		t.Errorf("expected to find an IP address for the request but was blank")
+	}
+	if got, exp := reqJSON.HTTPMethod, "GET"; got != exp {
+		t.Errorf("expected HTTP method to be '%s' but was '%s'", exp, got)
+	}
+	if got, exp := reqJSON.URL, "/1234abcd"; got != exp {
+		t.Errorf("expected request URL to be '%s' but was '%s'", exp, got)
+	}
+	if got, exp := reqJSON.Referer, ""; got != exp {
+		t.Errorf("expected request referer to be '%s' but was '%s'", exp, got)
+	}
+	if got, exp := reqJSON.Headers["Accept-Encoding"], "gzip"; got != exp {
+		t.Errorf("expected Accept-Encoding to be '%s' but was '%s'", exp, got)
+	}
+	if got, exp := reqJSON.Headers["User-Agent"], "Go-http-client"; !strings.Contains(got, exp) {
+		t.Errorf("expected user agent to contain '%s' but was '%s'", exp, got)
+	}
+}
+
+func TestRequestExtractorCanHandleAbsentContext(t *testing.T) {
+	if got := extractRequestInfo(nil); got != nil {
+		//really just testing that nothing panics here
+		t.Errorf("expected nil contexts to give nil sub-objects, but was '%s'", got)
+	}
+	if got := extractRequestInfo(context.Background()); got != nil {
+		//really just testing that nothing panics here
+		t.Errorf("expected contexts without requst info to give nil sub-objects, but was '%s'", got)
+	}
+}
+
+func TestParseHeadersWillSanitiseIllegalParams(t *testing.T) {
+	headers := make(map[string][]string)
+	headers["password"] = []string{"correct horse battery staple"}
+	headers["secret"] = []string{"I am Banksy"}
+	headers["authorization"] = []string{"licence to kill -9"}
+	for k, v := range parseRequestHeaders(headers) {
+		if v != "[REDACTED]" {
+			t.Errorf("expected '%s' to be [REDACTED], but was '%s'", k, v)
+		}
+	}
+}

--- a/request_extractor_test.go
+++ b/request_extractor_test.go
@@ -75,8 +75,8 @@ func TestParseHeadersWillSanitiseIllegalParams(t *testing.T) {
 	headers["secret"] = []string{"I am Banksy"}
 	headers["authorization"] = []string{"licence to kill -9"}
 	for k, v := range parseRequestHeaders(headers) {
-		if v != "[REDACTED]" {
-			t.Errorf("expected '%s' to be [REDACTED], but was '%s'", k, v)
+		if v != "[FILTERED]" {
+			t.Errorf("expected '%s' to be [FILTERED], but was '%s'", k, v)
 		}
 	}
 }

--- a/revel/request_extractor.go
+++ b/revel/request_extractor.go
@@ -1,0 +1,91 @@
+package bugsnagrevel
+
+import (
+	"strings"
+
+	bugsnag "github.com/bugsnag/bugsnag-go"
+	"github.com/revel/revel"
+)
+
+type headerExposer interface {
+	GetAll(string) []string
+}
+
+func extractRequestData(req *revel.Request, paramsFilters []string) *bugsnag.RequestJSON {
+	return &bugsnag.RequestJSON{
+		ClientIP: req.RemoteAddr,
+		// Revel requires you to know the name of the headers up front, which
+		// makes this bit tricky, especially if the application uses custom
+		// headers
+		Headers:    extractHeaders(req.Header, paramsFilters),
+		HTTPMethod: req.Method,
+		URL:        req.URL.String(),
+		Referer:    req.Header.Get("referer"),
+	}
+}
+
+// extractHeader is a best-guess workaround for pulling out as many headers as possible in a Revel request.
+// Extracts all the standard HTTP headers, and some non-standard, but common headers.
+func extractHeaders(h headerExposer, paramsFilters []string) map[string]string {
+	m := make(map[string]string)
+	// Standard headers
+	addHeader(paramsFilters, m, h, "Accept")
+	addHeader(paramsFilters, m, h, "Accept-Charset")
+	addHeader(paramsFilters, m, h, "Accept-Encoding")
+	addHeader(paramsFilters, m, h, "Accept-Language")
+	addHeader(paramsFilters, m, h, "Accept-Datetime")
+	addHeader(paramsFilters, m, h, "Access-Control-Request-Method")
+	addHeader(paramsFilters, m, h, "Access-Control-Request-Headers")
+	addHeader(paramsFilters, m, h, "Authorization")
+	addHeader(paramsFilters, m, h, "Cache-Control")
+	addHeader(paramsFilters, m, h, "Connection")
+	addHeader(paramsFilters, m, h, "Content-Length")
+	addHeader(paramsFilters, m, h, "Content-Type")
+	addHeader(paramsFilters, m, h, "Cookie")
+	addHeader(paramsFilters, m, h, "Date")
+	addHeader(paramsFilters, m, h, "Expect")
+	addHeader(paramsFilters, m, h, "Forwarded")
+	addHeader(paramsFilters, m, h, "From")
+	addHeader(paramsFilters, m, h, "Host")
+	addHeader(paramsFilters, m, h, "If-Match")
+	addHeader(paramsFilters, m, h, "If-Modified-Since")
+	addHeader(paramsFilters, m, h, "If-None-Match")
+	addHeader(paramsFilters, m, h, "If-Range")
+	addHeader(paramsFilters, m, h, "If-Unmodified-Since")
+	addHeader(paramsFilters, m, h, "Max-Forwards")
+	addHeader(paramsFilters, m, h, "Origin")
+	addHeader(paramsFilters, m, h, "Pragma")
+	addHeader(paramsFilters, m, h, "Proxy-Authorization")
+	addHeader(paramsFilters, m, h, "Range")
+	addHeader(paramsFilters, m, h, "Referer")
+	addHeader(paramsFilters, m, h, "TE")
+	addHeader(paramsFilters, m, h, "User-Agent")
+	addHeader(paramsFilters, m, h, "Upgrade")
+	addHeader(paramsFilters, m, h, "Via")
+	addHeader(paramsFilters, m, h, "Warning")
+
+	// Non-standard but common
+	addHeader(paramsFilters, m, h, "DNT")
+	addHeader(paramsFilters, m, h, "X-Requested-With")
+	addHeader(paramsFilters, m, h, "X-CSRF-Token")
+	return m
+}
+
+func addHeader(paramsFilters []string, m map[string]string, h headerExposer, headerName string) {
+	if val := h.GetAll(headerName); val != nil {
+		if contains(paramsFilters, strings.ToLower(headerName)) {
+			m[headerName] = "[REDACTED]"
+		} else {
+			m[headerName] = strings.Join(val, ",")
+		}
+	}
+}
+
+func contains(slice []string, sub string) bool {
+	for _, s := range slice {
+		if s == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/revel/request_extractor.go
+++ b/revel/request_extractor.go
@@ -74,7 +74,7 @@ func extractHeaders(h headerExposer, paramsFilters []string) map[string]string {
 func addHeader(paramsFilters []string, m map[string]string, h headerExposer, headerName string) {
 	if val := h.GetAll(headerName); val != nil {
 		if contains(paramsFilters, strings.ToLower(headerName)) {
-			m[headerName] = "[REDACTED]"
+			m[headerName] = "[FILTERED]"
 		} else {
 			m[headerName] = strings.Join(val, ",")
 		}

--- a/revel/request_extractor_test.go
+++ b/revel/request_extractor_test.go
@@ -1,0 +1,87 @@
+package bugsnagrevel
+
+import (
+	"testing"
+
+	"github.com/bugsnag/bugsnag-go"
+)
+
+type testExposer map[string]string
+
+func (te testExposer) GetAll(n string) []string {
+	return []string{te[n]}
+}
+
+func TestExtractingHeaders(t *testing.T) {
+	var te testExposer = make(map[string]string)
+	te["Accept"] = "application/json"
+	te["Accept-Charset"] = "utf-8"
+	te["Accept-Encoding"] = "gzip"
+	te["Accept-Language"] = "en-US"
+	te["Accept-Datetime"] = "Thu, 31 May 2007 20:35:00 GMT"
+	te["Access-Control-Request-Method"] = "GET"
+	te["Cache-Control"] = "no-cache"
+	te["Connection"] = "keep-alive"
+	te["Content-Length"] = "42"
+	te["Content-Type"] = "application/x-www-form-urlencoded"
+	te["Date"] = "Tue, 15 Nov 1994 08:12:31 GMT"
+	te["Expect"] = "100-continue"
+	te["Forwarded"] = "for=192.0.2.60; proto=http; by=203.0.113.43"
+	te["From"] = "user@example.com"
+	te["Host"] = "bugsnag.com"
+	te["If-Match"] = "737060cd8c284d8582d"
+	te["If-Modified-Since"] = "Sat, 29 Oct 1994 19:43:31 GMT"
+	te["If-None-Match"] = "737060cd8c284d8582d"
+	te["If-Range"] = "737060cd8c284d8582d"
+	te["If-Unmodified-Since"] = "Sat, 29 Oct 1994 19:43:31 GMT"
+	te["Max-Forwards"] = "29"
+	te["Origin"] = "https://bugsnag.com"
+	te["Pragma"] = "no-cache"
+	te["Proxy-Authorization"] = "Basic 2323jiojioIJOIOJIJ=="
+	te["Range"] = "bytes=400-999"
+	te["Referer"] = "https://bugsnag.com"
+	te["TE"] = "trailers"
+	te["User-Agent"] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36"
+	te["Upgrade"] = "h2c, HTTPS/1.3, IRC/6.9, RTA/x11, websocket"
+	te["Via"] = "1.0 fred, 1.1 bugsnag.com (Apache/1.1)"
+	te["Warning"] = "199 Miscellaneous warning"
+	te["DNT"] = "1"
+	te["X-Requested-With"] = "XMLHttpRequest"
+	te["X-CSRF-Token"] = "<TOKEN>"
+	m := extractHeaders(te, bugsnag.Config.ParamsFilters)
+	for k, v := range te {
+		if got, exp := m[k], v; exp != got {
+			t.Errorf("Expected '%s' to be '%s' but was '%s'", k, exp, got)
+		}
+	}
+
+	key := "Authorization"
+	te[key] = "Basic 34i3j4iom2323=="
+	m = extractHeaders(te, bugsnag.Config.ParamsFilters)
+	if got, exp := m[key], "[REDACTED]"; got != exp {
+		t.Errorf("Expected '%s' to be '%s' but was '%s'", key, exp, got)
+	}
+
+	key = "Cookie"
+	te[key] = "name=value"
+	m = extractHeaders(te, bugsnag.Config.ParamsFilters)
+	if got, exp := m[key], "[REDACTED]"; got != exp {
+		t.Errorf("Expected '%s' to be '%s' but was '%s'", key, exp, got)
+	}
+}
+
+type testMultiValExposer map[string][]string
+
+func (tmve testMultiValExposer) GetAll(n string) []string {
+	return tmve[n]
+}
+
+func TestSupportsMultipleValues(t *testing.T) {
+	var tmve testMultiValExposer = make(map[string][]string)
+	key := "Access-Control-Request-Headers"
+	tmve[key] = []string{"origin", "x-requested-with", "accept"}
+	m := extractHeaders(tmve, []string{})
+	if got, exp := m[key], "origin,x-requested-with,accept"; got != exp {
+		t.Errorf("Expected '%s' to be '%s' but was '%s'", key, exp, got)
+	}
+}

--- a/revel/request_extractor_test.go
+++ b/revel/request_extractor_test.go
@@ -58,14 +58,14 @@ func TestExtractingHeaders(t *testing.T) {
 	key := "Authorization"
 	te[key] = "Basic 34i3j4iom2323=="
 	m = extractHeaders(te, bugsnag.Config.ParamsFilters)
-	if got, exp := m[key], "[REDACTED]"; got != exp {
+	if got, exp := m[key], "[FILTERED]"; got != exp {
 		t.Errorf("Expected '%s' to be '%s' but was '%s'", key, exp, got)
 	}
 
 	key = "Cookie"
 	te[key] = "name=value"
 	m = extractHeaders(te, bugsnag.Config.ParamsFilters)
-	if got, exp := m[key], "[REDACTED]"; got != exp {
+	if got, exp := m[key], "[FILTERED]"; got != exp {
 		t.Errorf("Expected '%s' to be '%s' but was '%s'", key, exp, got)
 	}
 }

--- a/testutil/json.go
+++ b/testutil/json.go
@@ -84,6 +84,10 @@ func AssertPayload(t *testing.T, report *simplejson.Json, expPretty string) {
 		{got: event, exp: expEvent, prop: "severityReason.type"},
 		{got: event, exp: expEvent, prop: "metaData.request.httpMethod"},
 		{got: event, exp: expEvent, prop: "metaData.request.url"},
+		{got: event, exp: expEvent, prop: "request.httpMethod"},
+		{got: event, exp: expEvent, prop: "request.url"},
+		{got: event, exp: expEvent, prop: "request.referer"},
+		{got: event, exp: expEvent, prop: "request.headers.Accept-Encoding"},
 	} {
 		if got, exp := getString(tc.got, tc.prop), getString(tc.exp, tc.prop); got != exp {
 			t.Errorf("expected '%s' to be '%s' but was '%s'", tc.prop, exp, got)


### PR DESCRIPTION
Putting the `http.Request` object in the context (of the request - meta, I know) so that we can take it out when a `context.Context` is passed to `bugsnag.Notify` and get request information in the dashboard with minimal effort. Attempts to extract all the properties mentioned in the notify API.