### PR TITLE
Revert notify signature

### DIFF
--- a/bugsnag.go
+++ b/bugsnag.go
@@ -2,6 +2,7 @@ package bugsnag
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -63,7 +64,13 @@ func StartSession(ctx context.Context) context.Context {
 // information about it in the dashboard, or set the severity of the
 // notification.
 func Notify(err error, rawData ...interface{}) error {
-	return defaultNotifier.Notify(err, rawData...)
+	if e := checkForEmptyError(err); e != nil {
+		return e
+	}
+	// Stripping one stackframe to not include this function in the stacktrace
+	// for a manual notification.
+	skipFrames := 1
+	return defaultNotifier.Notify(errors.New(err, skipFrames), rawData...)
 }
 
 // AutoNotify logs a panic on a goroutine and then repanics.
@@ -88,7 +95,12 @@ func AutoNotify(rawData ...interface{}) {
 		severity := defaultNotifier.getDefaultSeverity(rawData, SeverityError)
 		state := HandledState{SeverityReasonHandledPanic, severity, true, ""}
 		rawData = append([]interface{}{state}, rawData...)
-		defaultNotifier.NotifySync(errors.New(err, 2), true, rawData...)
+		// We strip the following stackframes as they don't add much info
+		// - runtime/$arch - e.g. runtime/asm_amd64.s#call32
+		// - runtime/panic.go#gopanic
+		// Panics have their own stacktrace, so no stripping of the current stack
+		skipFrames := 2
+		defaultNotifier.NotifySync(errors.New(err, skipFrames), true, rawData...)
 		sessionTracker.FlushSessions()
 		panic(err)
 	}
@@ -121,7 +133,12 @@ func Recover(rawData ...interface{}) {
 		severity := defaultNotifier.getDefaultSeverity(rawData, SeverityWarning)
 		state := HandledState{SeverityReasonHandledPanic, severity, false, ""}
 		rawData = append([]interface{}{state}, rawData...)
-		defaultNotifier.Notify(errors.New(err, 2), rawData...)
+		// We strip the following stackframes as they don't add much info
+		// - runtime/$arch - e.g. runtime/asm_amd64.s#call32
+		// - runtime/panic.go#gopanic
+		// Panics have their own stacktrace, so no stripping of the current stack
+		skipFrames := 2
+		defaultNotifier.Notify(errors.New(err, skipFrames), rawData...)
 	}
 }
 
@@ -180,6 +197,18 @@ func HandlerFunc(h http.HandlerFunc, rawData ...interface{}) http.HandlerFunc {
 		defer notifier.AutoNotify(ctx)
 		h(w, request)
 	}
+}
+
+// checkForEmptyError checks if the given error (to be reported to Bugsnag) is
+// nil. If it is, then log an error messageand return another error wrapping
+// this error message.
+func checkForEmptyError(err error) error {
+	if err != nil {
+		return nil
+	}
+	msg := "attempted to notify Bugsnag without supplying an error. Bugsnag not notified"
+	Config.Logger.Printf("ERROR: " + msg)
+	return fmt.Errorf(msg)
 }
 
 func init() {

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -62,8 +62,8 @@ func StartSession(ctx context.Context) context.Context {
 // error. For example you can pass the current http.Request to Bugsnag to see
 // information about it in the dashboard, or set the severity of the
 // notification.
-func Notify(rawData ...interface{}) error {
-	return defaultNotifier.Notify(rawData...)
+func Notify(err error, rawData ...interface{}) error {
+	return defaultNotifier.Notify(err, rawData...)
 }
 
 // AutoNotify logs a panic on a goroutine and then repanics.
@@ -88,7 +88,7 @@ func AutoNotify(rawData ...interface{}) {
 		severity := defaultNotifier.getDefaultSeverity(rawData, SeverityError)
 		state := HandledState{SeverityReasonHandledPanic, severity, true, ""}
 		rawData = append([]interface{}{state}, rawData...)
-		defaultNotifier.NotifySync(append(rawData, errors.New(err, 2), true)...)
+		defaultNotifier.NotifySync(errors.New(err, 2), true, rawData...)
 		sessionTracker.FlushSessions()
 		panic(err)
 	}
@@ -121,7 +121,7 @@ func Recover(rawData ...interface{}) {
 		severity := defaultNotifier.getDefaultSeverity(rawData, SeverityWarning)
 		state := HandledState{SeverityReasonHandledPanic, severity, false, ""}
 		rawData = append([]interface{}{state}, rawData...)
-		defaultNotifier.Notify(append(rawData, errors.New(err, 2))...)
+		defaultNotifier.Notify(errors.New(err, 2), rawData...)
 	}
 }
 

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -54,15 +54,14 @@ func StartSession(ctx context.Context) context.Context {
 }
 
 // Notify sends an error.Error to Bugsnag along with the current stack trace.
-// Although it's not strictly enforced, it's highly recommended to pass a
-// context.Context object that has at one-point been returned from
-// bugsnag.StartSession. Doing so ensures your stability score remains accurate,
-// and future versions of Bugsnag may extract more useful information from this
-// context.
-// The remaining rawData is used to send extra information along with the
-// error. For example you can pass the current http.Request to Bugsnag to see
-// information about it in the dashboard, or set the severity of the
-// notification.
+// If at all possible, it is recommended to pass in a context.Context, e.g.
+// from a http.Request or bugsnag.StartSession() as Bugsnag will be able to
+// extract additional information in some cases. The rawData is used to send
+// extra information along with the error. For example you can pass the current
+// http.Request to Bugsnag to see information about it in the dashboard, or set
+// the severity of the notification. For a detailed list of the information
+// that can be extracted, see
+// https://docs.bugsnag.com/platforms/go/reporting-handled-errors/
 func Notify(err error, rawData ...interface{}) error {
 	if e := checkForEmptyError(err); e != nil {
 		return e

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -199,7 +199,7 @@ func HandlerFunc(h http.HandlerFunc, rawData ...interface{}) http.HandlerFunc {
 }
 
 // checkForEmptyError checks if the given error (to be reported to Bugsnag) is
-// nil. If it is, then log an error messageand return another error wrapping
+// nil. If it is, then log an error message and return another error wrapping
 // this error message.
 func checkForEmptyError(err error) error {
 	if err != nil {

--- a/bugsnag_example_test.go
+++ b/bugsnag_example_test.go
@@ -101,7 +101,7 @@ func ExampleNotify() {
 	_, err := net.Listen("tcp", ":80")
 
 	if err != nil {
-		bugsnag.Notify(ctx, err)
+		bugsnag.Notify(err, ctx)
 	}
 }
 
@@ -111,7 +111,7 @@ func ExampleNotify_details() {
 	_, err := net.Listen("tcp", ":80")
 
 	if err != nil {
-		bugsnag.Notify(ctx, err,
+		bugsnag.Notify(err, ctx,
 			// show as low-severity
 			bugsnag.SeverityInfo,
 			// set the context

--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -93,8 +93,8 @@ func TestNotify(t *testing.T) {
 	})
 
 	Notify(
-		StartSession(context.Background()),
 		fmt.Errorf("hello world"),
+		StartSession(context.Background()),
 		generateSampleConfig(ts.URL),
 		User{Id: "123", Name: "Conrad", Email: "me@cirw.in"},
 		Context{"testing"},
@@ -425,7 +425,7 @@ func TestSeverityReasonNotifyCallback(t *testing.T) {
 		return nil
 	})
 
-	Notify(StartSession(context.Background()), fmt.Errorf("hello world"), generateSampleConfig(ts.URL))
+	Notify(fmt.Errorf("hello world"), generateSampleConfig(ts.URL), StartSession(context.Background()))
 
 	json, _ := simplejson.NewJson(<-reports)
 	assertPayload(t, json, eventJSON{
@@ -453,7 +453,7 @@ func TestNotifyWithoutError(t *testing.T) {
 	config.Logger = &l
 	Configure(config)
 
-	Notify(StartSession(context.Background()))
+	Notify(nil, StartSession(context.Background()))
 
 	select {
 	case r := <-reports:

--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -492,7 +492,7 @@ func TestNotifyWithoutError(t *testing.T) {
 
 	select {
 	case r := <-reports:
-		t.Fatalf("Unexpected request made to bugsnag: %+v", r)
+		t.Fatalf("Unexpected request made to bugsnag: %+v", string(r))
 	default:
 		for _, exp := range []string{"ERROR", "error", "Bugsnag", "not notified"} {
 			if got := l.msg; !strings.Contains(got, exp) {

--- a/event.go
+++ b/event.go
@@ -128,7 +128,7 @@ func newEvent(rawData []interface{}, notifier *Notifier) (*Event, *Configuration
 		switch datum := datum.(type) {
 
 		case error, errors.Error:
-			err = errors.New(datum.(error), 4)
+			err = errors.New(datum.(error), 1)
 			event.Error = err
 			event.ErrorClass = err.TypeName()
 			event.Message = err.Error()

--- a/gin/gin_test.go
+++ b/gin/gin_test.go
@@ -128,7 +128,7 @@ func TestGin(t *testing.T) {
 
 func performHandledError(c *gin.Context) {
 	ctx := c.Request.Context()
-	bugsnag.Notify(ctx, fmt.Errorf("Ooopsie"), bugsnag.User{Id: "987zyx"})
+	bugsnag.Notify(fmt.Errorf("Ooopsie"), ctx, bugsnag.User{Id: "987zyx"})
 }
 
 func performUnhandledCrash(c *gin.Context) {

--- a/martini/martini_test.go
+++ b/martini/martini_test.go
@@ -16,7 +16,7 @@ import (
 
 func performHandledError(notifier *bugsnag.Notifier, r *http.Request) {
 	ctx := r.Context()
-	notifier.Notify(ctx, fmt.Errorf("Ooopsie"), bugsnag.User{Id: "987zyx"})
+	notifier.Notify(fmt.Errorf("Ooopsie"), ctx, bugsnag.User{Id: "987zyx"})
 }
 
 func performUnhandledCrash() {

--- a/negroni/negroni_test.go
+++ b/negroni/negroni_test.go
@@ -83,8 +83,9 @@ func TestNegroni(t *testing.T) {
 func unhandledCrashHandler(w http.ResponseWriter, req *http.Request) {
 	panic("something went terribly wrong")
 }
+
 func handledCrashHandler(w http.ResponseWriter, req *http.Request) {
-	bugsnag.Notify(req.Context(), fmt.Errorf("Ooopsie"))
+	bugsnag.Notify(fmt.Errorf("Ooopsie"), req.Context())
 }
 
 func crash(a interface{}) string {

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -33,7 +33,7 @@ func TestStackframesAreSkippedCorrectly(t *testing.T) {
 		Endpoints: bugsnag.Endpoints{Notify: ts.URL, Sessions: ts.URL + "/sessions"},
 	})
 
-	// Expect the following frames to be ignored for *.Notify
+	// Expect the following frames to be present for *.Notify
 	/*
 		{ "file": "$GOPATH/src/github.com/bugsnag/bugsnag-go/notifier_test.go", "method": "TestStackframesAreSkippedCorrectly.func1" },
 		{ "file": "testing/testing.go", "method": "tRunner" },
@@ -49,7 +49,7 @@ func TestStackframesAreSkippedCorrectly(t *testing.T) {
 		assertStackframeCount(st, 3)
 	})
 
-	// Expect the following frames to be ignored for notifier.NotifySync
+	// Expect the following frames to be present for notifier.NotifySync
 	/*
 		{ "file": "$GOPATH/src/github.com/bugsnag/bugsnag-go/notifier_test.go", "method": "TestStackframesAreSkippedCorrectly.func2" },
 		{ "file": "testing/testing.go", "method": "tRunner" },
@@ -61,7 +61,7 @@ func TestStackframesAreSkippedCorrectly(t *testing.T) {
 		assertStackframeCount(st, 3)
 	})
 
-	// Expect the following frames to be ignored for *.AutoNotify
+	// Expect the following frames to be present for *.AutoNotify
 	/*
 		{ "file": "runtime/panic.go", "method": "gopanic" },
 		{ "file": "runtime/iface.go", "method": "panicdottypeE" },
@@ -87,7 +87,7 @@ func TestStackframesAreSkippedCorrectly(t *testing.T) {
 		assertStackframeCount(st, 6)
 	})
 
-	// Expect the following frames to be ignored for *.Recover
+	// Expect the following frames to be present for *.Recover
 	/*
 		{ "file": "runtime/panic.go", "method": "gopanic" },
 		{ "file": "runtime/iface.go", "method": "panicdottypeE" },

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -1,0 +1,123 @@
+package bugsnag_test
+
+import (
+	"fmt"
+	"testing"
+
+	simplejson "github.com/bitly/go-simplejson"
+	"github.com/bugsnag/bugsnag-go"
+	. "github.com/bugsnag/bugsnag-go/testutil"
+)
+
+var bugsnaggedReports chan []byte
+
+func notifierSetup(url string) *bugsnag.Notifier {
+	return bugsnag.New(bugsnag.Configuration{
+		APIKey:    TestAPIKey,
+		Endpoints: bugsnag.Endpoints{Notify: url, Sessions: url + "/sessions"},
+	})
+}
+
+func crash(s interface{}) int {
+	return s.(int)
+}
+
+func TestStackframesAreSkippedCorrectly(t *testing.T) {
+	ts, reports := Setup()
+	bugsnaggedReports = reports
+	defer ts.Close()
+	notifier := notifierSetup(ts.URL)
+
+	bugsnag.Configure(bugsnag.Configuration{
+		APIKey:    TestAPIKey,
+		Endpoints: bugsnag.Endpoints{Notify: ts.URL, Sessions: ts.URL + "/sessions"},
+	})
+
+	// Expect the following frames to be ignored for *.Notify
+	/*
+		{ "file": "$GOPATH/src/github.com/bugsnag/bugsnag-go/notifier_test.go", "method": "TestStackframesAreSkippedCorrectly.func1" },
+		{ "file": "testing/testing.go", "method": "tRunner" },
+		{ "file": "runtime/asm_amd64.s", "method": "goexit" }
+	*/
+
+	t.Run("notifier.Notify", func(st *testing.T) {
+		notifier.Notify(fmt.Errorf("oopsie"))
+		assertStackframeCount(st, 3)
+	})
+	t.Run("bugsnag.Notify", func(st *testing.T) {
+		bugsnag.Notify(fmt.Errorf("oopsie"))
+		assertStackframeCount(st, 3)
+	})
+
+	// Expect the following frames to be ignored for notifier.NotifySync
+	/*
+		{ "file": "$GOPATH/src/github.com/bugsnag/bugsnag-go/notifier_test.go", "method": "TestStackframesAreSkippedCorrectly.func2" },
+		{ "file": "testing/testing.go", "method": "tRunner" },
+		{ "file": "runtime/asm_amd64.s", "method": "goexit" }
+	*/
+
+	t.Run("notifier.NotifySync", func(st *testing.T) {
+		notifier.NotifySync(fmt.Errorf("oopsie"), true)
+		assertStackframeCount(st, 3)
+	})
+
+	// Expect the following frames to be ignored for *.AutoNotify
+	/*
+		{ "file": "runtime/panic.go", "method": "gopanic" },
+		{ "file": "runtime/iface.go", "method": "panicdottypeE" },
+		{ "file": "$GOPATH/src/github.com/bugsnag/bugsnag-go/notifier_test.go", "method": "TestStackframesAreSkippedCorrectly.func2.1" },
+		{ "file": "$GOPATH/src/github.com/bugsnag/bugsnag-go/notifier_test.go", "method": "TestStackframesAreSkippedCorrectly.func3" },
+		{ "file": "testing/testing.go", "method": "tRunner" },
+		{ "file": "runtime/asm_amd64.s", "method": "goexit" }
+	*/
+	t.Run("notifier.AutoNotify", func(st *testing.T) {
+		func() {
+			defer func() { recover() }()
+			defer notifier.AutoNotify()
+			crash("NaN")
+		}()
+		assertStackframeCount(st, 6)
+	})
+	t.Run("bugsnag.AutoNotify", func(st *testing.T) {
+		func() {
+			defer func() { recover() }()
+			defer bugsnag.AutoNotify()
+			crash("NaN")
+		}()
+		assertStackframeCount(st, 6)
+	})
+
+	// Expect the following frames to be ignored for *.Recover
+	/*
+		{ "file": "runtime/panic.go", "method": "gopanic" },
+		{ "file": "runtime/iface.go", "method": "panicdottypeE" },
+		{ "file": "$GOPATH/src/github.com/bugsnag/bugsnag-go/notifier_test.go", "method": "TestStackframesAreSkippedCorrectly.func4.1" },
+		{ "file": "$GOPATH/src/github.com/bugsnag/bugsnag-go/notifier_test.go", "method": "TestStackframesAreSkippedCorrectly.func4" },
+		{ "file": "testing/testing.go", "method": "tRunner" },
+		{ "file": "runtime/asm_amd64.s", "method": "goexit" }
+	*/
+	t.Run("notifier.Recover", func(st *testing.T) {
+		func() {
+			defer notifier.Recover()
+			crash("NaN")
+		}()
+		assertStackframeCount(st, 6)
+	})
+	t.Run("bugsnag.Recover", func(st *testing.T) {
+		func() {
+			defer bugsnag.Recover()
+			crash("NaN")
+		}()
+		assertStackframeCount(st, 6)
+	})
+}
+
+func assertStackframeCount(t *testing.T, expCount int) {
+	report, _ := simplejson.NewJson(<-bugsnaggedReports)
+	stacktrace := GetIndex(GetIndex(report, "events", 0), "exceptions", 0).Get("stacktrace")
+	if s := stacktrace.MustArray(); len(s) != expCount {
+		t.Errorf("Expected %d stackframe(s), but there were %d stackframes", expCount, len(s))
+		s, _ := stacktrace.EncodePretty()
+		t.Errorf(string(s))
+	}
+}

--- a/report_publisher.go
+++ b/report_publisher.go
@@ -1,0 +1,27 @@
+package bugsnag
+
+import "fmt"
+
+type reportPublisher interface {
+	publishReport(*payload) error
+}
+
+type defaultReportPublisher struct{}
+
+func (*defaultReportPublisher) publishReport(p *payload) error {
+	p.logf("notifying bugsnag: %s", p.Message)
+	if !p.notifyInReleaseStage() {
+		return fmt.Errorf("not notifying in %s", p.ReleaseStage)
+	}
+	if p.Synchronous {
+		return p.deliver()
+	}
+
+	go func(p *payload) {
+		if err := p.deliver(); err != nil {
+			// Ensure that any errors are logged if they occur in a goroutine.
+			p.logf("bugsnag/defaultReportPublisher.publishReport: %v", err)
+		}
+	}(p)
+	return nil
+}

--- a/testutil/json.go
+++ b/testutil/json.go
@@ -2,7 +2,6 @@
 package testutil
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -21,7 +20,6 @@ const TestAPIKey = "166f5ad3590596f9aa8d601ea89af845"
 func Setup() (*httptest.Server, chan []byte) {
 	reports := make(chan []byte, 10)
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Println("Bugsnag called")
 		if strings.Contains(r.URL.Path, "sessions") {
 			return
 		}


### PR DESCRIPTION
This reverts a previous change that was made to make the go notifier a bit more idiomatic. However, we don't intend on making the addition of session tracking a major release, semver-ily speaking, and this is strictly speaking a breaking change.

The change of signature from

```go
bugsnag.Notify(err error, rawData... interface{})
```

to

```go
bugsnag.Notify(rawData... interface{})
```

wouldn't break directly for users who just call this function as-is, it would be breaking in the case that users decide to create a type alias for the function signature of our client, in order to facilitate testing or passing the function outside packages or libraries.

Also added a test to gain some more confidence that `notifier.NotifySync` allows you to override the async default, and that this state won't be persisted to later `bugsnag.Notify` calls.