### PR TITLE
[fix] Make NotifyReleaseStages apply to sessions

### DIFF
--- a/bugsnag.go
+++ b/bugsnag.go
@@ -250,16 +250,17 @@ func init() {
 func startSessionTracking() {
 	if sessionTracker == nil {
 		sessionTrackingConfig.Update(&sessions.SessionTrackingConfiguration{
-			APIKey:          Config.APIKey,
-			Endpoint:        Config.Endpoints.Sessions,
-			Version:         VERSION,
-			PublishInterval: DefaultSessionPublishInterval,
-			Transport:       Config.Transport,
-			ReleaseStage:    Config.ReleaseStage,
-			Hostname:        Config.Hostname,
-			AppType:         Config.AppType,
-			AppVersion:      Config.AppVersion,
-			Logger:          Config.Logger,
+			APIKey:              Config.APIKey,
+			Endpoint:            Config.Endpoints.Sessions,
+			Version:             VERSION,
+			PublishInterval:     DefaultSessionPublishInterval,
+			Transport:           Config.Transport,
+			ReleaseStage:        Config.ReleaseStage,
+			Hostname:            Config.Hostname,
+			AppType:             Config.AppType,
+			AppVersion:          Config.AppVersion,
+			NotifyReleaseStages: Config.NotifyReleaseStages,
+			Logger:              Config.Logger,
 		})
 		sessionTracker = sessions.NewSessionTracker(&sessionTrackingConfig)
 	}

--- a/sessions/config.go
+++ b/sessions/config.go
@@ -35,6 +35,11 @@ type SessionTrackingConfiguration struct {
 	// Transport defines the http.RoundTripper to be used for managing HTTP requests.
 	Transport http.RoundTripper
 
+	// The release stages to notify about sessions in. If you set this then
+	// bugsnag-go will only send sessions to Bugsnag if the release stage
+	// is listed here.
+	NotifyReleaseStages []string
+
 	// Logger is the logger that Bugsnag should log to. Uses the same defaults
 	// as go's builtin logging package. This logger gets invoked when any error
 	// occurs inside the library itself.

--- a/sessions/config_test.go
+++ b/sessions/config_test.go
@@ -2,6 +2,7 @@ package sessions
 
 import (
 	"net/http"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -24,9 +25,10 @@ func TestConfigDoesNotChangeGivenBlankValues(t *testing.T) {
 		{"AppType", exp.AppType, c.AppType},
 		{"AppVersion", exp.AppVersion, c.AppVersion},
 		{"Transport", exp.Transport, c.Transport},
+		{"NotifyReleaseStages", exp.NotifyReleaseStages, c.NotifyReleaseStages},
 	}
 	for _, tc := range tt {
-		if tc.got != tc.expected {
+		if !reflect.DeepEqual(tc.got, tc.expected) {
 			t.Errorf("Expected '%s' to be '%v' but was '%v'", tc.name, tc.expected, tc.got)
 		}
 	}
@@ -35,14 +37,15 @@ func TestConfigDoesNotChangeGivenBlankValues(t *testing.T) {
 func TestConfigUpdatesGivenNonDefaultValues(t *testing.T) {
 	c := testConfig()
 	exp := SessionTrackingConfiguration{
-		PublishInterval: 40 * time.Second,
-		APIKey:          "api234",
-		Endpoint:        "https://docs.bugsnag.com/platforms/go/",
-		Version:         "2.7.3",
-		ReleaseStage:    "Production",
-		Hostname:        "Brian's Surface",
-		AppType:         "Revel API",
-		AppVersion:      "6.3.9",
+		PublishInterval:     40 * time.Second,
+		APIKey:              "api234",
+		Endpoint:            "https://docs.bugsnag.com/platforms/go/",
+		Version:             "2.7.3",
+		ReleaseStage:        "Production",
+		Hostname:            "Brian's Surface",
+		AppType:             "Revel API",
+		AppVersion:          "6.3.9",
+		NotifyReleaseStages: []string{"staging", "production"},
 	}
 	c.Update(&exp)
 	tt := []struct {
@@ -58,9 +61,10 @@ func TestConfigUpdatesGivenNonDefaultValues(t *testing.T) {
 		{"Hostname", exp.Hostname, c.Hostname},
 		{"AppType", exp.AppType, c.AppType},
 		{"AppVersion", exp.AppVersion, c.AppVersion},
+		{"NotifyReleaseStages", exp.NotifyReleaseStages, c.NotifyReleaseStages},
 	}
 	for _, tc := range tt {
-		if tc.got != tc.expected {
+		if !reflect.DeepEqual(tc.got, tc.expected) {
 			t.Errorf("Expected '%s' to be '%v' but was '%v'", tc.name, tc.expected, tc.got)
 		}
 	}
@@ -68,14 +72,15 @@ func TestConfigUpdatesGivenNonDefaultValues(t *testing.T) {
 
 func testConfig() SessionTrackingConfiguration {
 	return SessionTrackingConfiguration{
-		PublishInterval: 20 * time.Second,
-		APIKey:          "api123",
-		Endpoint:        "https://bugsnag.com/jobs", //If you like what you see... ;)
-		Version:         "1.6.2",
-		ReleaseStage:    "Staging",
-		Hostname:        "Russ's MacbookPro",
-		AppType:         "Gin API",
-		AppVersion:      "5.2.8",
-		Transport:       http.DefaultTransport,
+		PublishInterval:     20 * time.Second,
+		APIKey:              "api123",
+		Endpoint:            "https://bugsnag.com/jobs", //If you like what you see... ;)
+		Version:             "1.6.2",
+		ReleaseStage:        "Staging",
+		Hostname:            "Russ's MacbookPro",
+		AppType:             "Gin API",
+		AppVersion:          "5.2.8",
+		NotifyReleaseStages: []string{"staging", "production"},
+		Transport:           http.DefaultTransport,
 	}
 }

--- a/sessions/publisher.go
+++ b/sessions/publisher.go
@@ -37,7 +37,7 @@ func (p *publisher) publish(sessions []*Session) error {
 		return nil
 	}
 	nrs, rs := p.config.NotifyReleaseStages, p.config.ReleaseStage
-	if nrs != nil && !contains(nrs, rs) {
+	if rs == "" || nrs != nil && !contains(nrs, rs) {
 		// Don't want to send any sessions when notify release stages
 		return nil
 	}

--- a/sessions/publisher.go
+++ b/sessions/publisher.go
@@ -36,6 +36,11 @@ func (p *publisher) publish(sessions []*Session) error {
 		// log every minute
 		return nil
 	}
+	nrs, rs := p.config.NotifyReleaseStages, p.config.ReleaseStage
+	if nrs != nil && !contains(nrs, rs) {
+		// Don't want to send any sessions when notify release stages
+		return nil
+	}
 	if len(sessions) == 0 {
 		return fmt.Errorf("bugsnag/sessions/publisher.publish requested publication of 0")
 	}
@@ -66,4 +71,13 @@ func (p *publisher) publish(sessions []*Session) error {
 		return fmt.Errorf("bugsnag/session.publish expected 202 response status, got HTTP %s", res.Status)
 	}
 	return nil
+}
+
+func contains(coll []string, e string) bool {
+	for _, s := range coll {
+		if s == e {
+			return true
+		}
+	}
+	return false
 }

--- a/sessions/publisher.go
+++ b/sessions/publisher.go
@@ -37,8 +37,9 @@ func (p *publisher) publish(sessions []*Session) error {
 		return nil
 	}
 	nrs, rs := p.config.NotifyReleaseStages, p.config.ReleaseStage
-	if rs == "" || nrs != nil && !contains(nrs, rs) {
-		// Don't want to send any sessions when notify release stages
+	if rs != "" && (nrs != nil && !contains(nrs, rs)) {
+		// Always send sessions if the release stage is not set, but don't send any
+		// sessions when notify release stages don't match the current release stage
 		return nil
 	}
 	if len(sessions) == 0 {

--- a/sessions/publisher_test.go
+++ b/sessions/publisher_test.go
@@ -174,6 +174,27 @@ func TestNoSessionsOutsideNotifyReleaseStages(t *testing.T) {
 	}
 }
 
+func TestReleaseStageNotSetSendsSessionsRegardlessOfNotifyReleaseStages(t *testing.T) {
+	sessions, _ := makeSessions()
+
+	testClient := testHTTPClient{}
+	config := makeHeavyConfig()
+	config.NotifyReleaseStages = []string{"staging", "production"}
+	config.ReleaseStage = ""
+	publisher := publisher{
+		config: config,
+		client: &testClient,
+	}
+
+	err := publisher.publish(sessions)
+	if err != nil {
+		t.Error(err)
+	}
+	if exp, got := 1, len(testClient.reqs); got != exp {
+		t.Errorf("Expected %d sessions sent when the release stage is \"\" regardless of notify release stage, but got %d", exp, got)
+	}
+}
+
 func makeHeavyConfig() *SessionTrackingConfiguration {
 	return &SessionTrackingConfiguration{
 		AppType:             "gin",

--- a/sessions/publisher_test.go
+++ b/sessions/publisher_test.go
@@ -154,7 +154,7 @@ func TestSendsCorrectPayloadForBigConfig(t *testing.T) {
 	}
 }
 
-func TestNoSessionsOutsideNotifyReleaseSTages(t *testing.T) {
+func TestNoSessionsOutsideNotifyReleaseStages(t *testing.T) {
 	sessions, _ := makeSessions()
 
 	testClient := testHTTPClient{}


### PR DESCRIPTION
We were previously still sending sessions if the release stage was outside a defined set of acceptable notify release stages. This PR fixes that.