### PR TITLE
Maze tests for Martini, Negroni and Gin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 maze_output
 vendor
 features/fixtures/martini/martini
+features/fixtures/negroni/negroni

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 # Ignore maze runner generated files
 maze_output
 vendor
-*/martini
+features/fixtures/martini/martini

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Ignore maze runner generated files
 maze_output
 vendor
+*/martini

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ maze_output
 vendor
 features/fixtures/martini/martini
 features/fixtures/negroni/negroni
+features/fixtures/gin/gin

--- a/features/apptype.feature
+++ b/features/apptype.feature
@@ -1,5 +1,17 @@
 Feature: Configuring app type
 
+Scenario: A martini error report contains the configured app type
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "APP_TYPE" to "background-queue"
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "app.type" equals "background-queue"
+
 Scenario: An error report contains the configured app type
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/apptype.feature
+++ b/features/apptype.feature
@@ -1,29 +1,5 @@
 Feature: Configuring app type
 
-Scenario: A negroni error report contains the configured app type
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new negroni app
-  And I configure the bugsnag notify endpoint only
-  And I set environment variable "APP_TYPE" to "background-queue"
-  When I run the script "features/fixtures/negroni/run.sh"
-  And I go to the negroni route "/handled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "app.type" equals "background-queue"
-
-Scenario: A martini error report contains the configured app type
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
-  And I configure the bugsnag notify endpoint only
-  And I set environment variable "APP_TYPE" to "background-queue"
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/handled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "app.type" equals "background-queue"
-
 Scenario: An error report contains the configured app type
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/apptype.feature
+++ b/features/apptype.feature
@@ -1,5 +1,17 @@
 Feature: Configuring app type
 
+Scenario: A negroni error report contains the configured app type
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "APP_TYPE" to "background-queue"
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "app.type" equals "background-queue"
+
 Scenario: A martini error report contains the configured app type
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I am working with a new martini app

--- a/features/appversion.feature
+++ b/features/appversion.feature
@@ -1,5 +1,17 @@
 Feature: Configuring app version
 
+Scenario: A negroni error report contains the configured app version
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "APP_VERSION" to "1.3.56"
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "app.version" equals "1.3.56"
+
 Scenario: A martini error report contains the configured app version
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I am working with a new martini app

--- a/features/appversion.feature
+++ b/features/appversion.feature
@@ -1,5 +1,17 @@
 Feature: Configuring app version
 
+Scenario: A martini error report contains the configured app version
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "APP_VERSION" to "1.3.56"
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "app.version" equals "1.3.56"
+
 Scenario: An error report contains the configured app version
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/appversion.feature
+++ b/features/appversion.feature
@@ -1,29 +1,5 @@
 Feature: Configuring app version
 
-Scenario: A negroni error report contains the configured app version
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new negroni app
-  And I configure the bugsnag notify endpoint only
-  And I set environment variable "APP_VERSION" to "1.3.56"
-  When I run the script "features/fixtures/negroni/run.sh"
-  And I go to the negroni route "/handled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "app.version" equals "1.3.56"
-
-Scenario: A martini error report contains the configured app version
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
-  And I configure the bugsnag notify endpoint only
-  And I set environment variable "APP_VERSION" to "1.3.56"
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/handled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "app.version" equals "1.3.56"
-
 Scenario: An error report contains the configured app version
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/autocapturesessions.feature
+++ b/features/autocapturesessions.feature
@@ -1,27 +1,5 @@
 Feature: Configure auto capture sessions
 
-Scenario: Disabling auto capture sessions for negroni
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new negroni app
-  And I configure the bugsnag endpoints
-  And I set environment variable "AUTO_CAPTURE_SESSIONS" to "false"
-  When I run the script "features/fixtures/negroni/run.sh"
-  And I go to the negroni route "/handled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-
-Scenario: Disabling auto capture sessions for martini
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
-  And I configure the bugsnag endpoints
-  And I set environment variable "AUTO_CAPTURE_SESSIONS" to "false"
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/handled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-
 Scenario: An error report and session report is sent when auto capture sessions is on using the net http framework
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/autocapturesessions.feature
+++ b/features/autocapturesessions.feature
@@ -1,5 +1,16 @@
 Feature: Configure auto capture sessions
 
+Scenario: Disabling auto capture sessions for negroni
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new negroni app
+  And I configure the bugsnag endpoints
+  And I set environment variable "AUTO_CAPTURE_SESSIONS" to "false"
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
 Scenario: Disabling auto capture sessions for martini
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I am working with a new martini app

--- a/features/autocapturesessions.feature
+++ b/features/autocapturesessions.feature
@@ -1,5 +1,16 @@
 Feature: Configure auto capture sessions
 
+Scenario: Disabling auto capture sessions for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag endpoints
+  And I set environment variable "AUTO_CAPTURE_SESSIONS" to "false"
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
 Scenario: An error report and session report is sent when auto capture sessions is on using the net http framework
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/autonotify.feature
+++ b/features/autonotify.feature
@@ -1,5 +1,16 @@
 Feature: Using auto notify
 
+Scenario: An error report is sent when a martini request panics
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/unhandled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is true
+
 Scenario: An error report is sent when a go routine crashes
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/autonotify.feature
+++ b/features/autonotify.feature
@@ -1,27 +1,5 @@
 Feature: Using auto notify
 
-Scenario: An error report is sent when a negroni request panics
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new negroni app
-  And I configure the bugsnag notify endpoint only
-  When I run the script "features/fixtures/negroni/run.sh"
-  And I go to the negroni route "/unhandled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "unhandled" is true
-
-Scenario: An error report is sent when a martini request panics
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
-  And I configure the bugsnag notify endpoint only
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/unhandled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "unhandled" is true
-
 Scenario: An error report is sent when a go routine crashes
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/autonotify.feature
+++ b/features/autonotify.feature
@@ -1,5 +1,16 @@
 Feature: Using auto notify
 
+Scenario: An error report is sent when a negroni request panics
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/unhandled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is true
+
 Scenario: An error report is sent when a martini request panics
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I am working with a new martini app

--- a/features/endpoint.feature
+++ b/features/endpoint.feature
@@ -1,6 +1,6 @@
 Feature: Configuring endpoint
 
-Scenario: An error report is sent when a martini request panics
+Scenario: An error report is sent when a martini is configured to use the legacy endpoint
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I set the legacy endpoint only
   And I am working with a new martini app

--- a/features/endpoint.feature
+++ b/features/endpoint.feature
@@ -1,25 +1,5 @@
 Feature: Configuring endpoint
 
-Scenario: An error report is sent when a negroni is configured to use the legacy endpoint
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I set the legacy endpoint only
-  And I am working with a new negroni app
-  When I run the script "features/fixtures/negroni/run.sh"
-  And I go to the negroni route "/handled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-
-Scenario: An error report is sent when a martini is configured to use the legacy endpoint
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I set the legacy endpoint only
-  And I am working with a new martini app
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/handled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-
 Scenario: An error report is sent successfully using the legacy endpoint
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/endpoint.feature
+++ b/features/endpoint.feature
@@ -1,5 +1,15 @@
 Feature: Configuring endpoint
 
+Scenario: An error report is sent when a martini request panics
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I set the legacy endpoint only
+  And I am working with a new martini app
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
 Scenario: An error report is sent successfully using the legacy endpoint
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/endpoint.feature
+++ b/features/endpoint.feature
@@ -1,5 +1,15 @@
 Feature: Configuring endpoint
 
+Scenario: An error report is sent when a negroni is configured to use the legacy endpoint
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I set the legacy endpoint only
+  And I am working with a new negroni app
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
 Scenario: An error report is sent when a martini is configured to use the legacy endpoint
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I set the legacy endpoint only

--- a/features/fixtures/gin/main.go
+++ b/features/fixtures/gin/main.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/bugsnag/bugsnag-go"
+	"github.com/bugsnag/bugsnag-go/gin"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	g := gin.Default()
+	config := bugsnag.Configuration{
+		AppVersion: os.Getenv("APP_VERSION"),
+		AppType:    os.Getenv("APP_TYPE"),
+		APIKey:     os.Getenv("API_KEY"),
+		Endpoint:   os.Getenv("ENDPOINT"),
+		Endpoints: bugsnag.Endpoints{
+			Notify:   os.Getenv("NOTIFY_ENDPOINT"),
+			Sessions: os.Getenv("SESSIONS_ENDPOINT"),
+		},
+		Hostname:     os.Getenv("HOSTNAME"),
+		ReleaseStage: os.Getenv("RELEASE_STAGE"),
+	}
+
+	if stages := os.Getenv("NOTIFY_RELEASE_STAGES"); stages != "" {
+		config.NotifyReleaseStages = []string{stages}
+	}
+
+	if acs, _ := strconv.ParseBool(os.Getenv("AUTO_CAPTURE_SESSIONS")); acs {
+		config.AutoCaptureSessions = acs
+	}
+
+	if filters := os.Getenv("PARAMS_FILTERS"); filters != "" {
+		config.ParamsFilters = []string{filters}
+
+	}
+
+	config.Synchronous, _ = strconv.ParseBool(os.Getenv("SYNCHRONOUS"))
+	bugsnag.Configure(config)
+
+	g.Use(bugsnaggin.AutoNotify(config))
+
+	g.GET("/unhandled", unhandledCrash)
+	g.GET("/handled", handledError)
+	g.GET("/metadata", metadata)
+	g.GET("/onbeforenotify", onbeforenotify)
+	g.GET("/recover", dontdie)
+	g.GET("/async", async)
+	g.GET("/user", user)
+
+	g.Run(":9050") // listen and serve on 0.0.0.0:9001
+}
+
+func unhandledCrash(c *gin.Context) {
+	// Invalid type assertion, will panic
+	func(a interface{}) string { return a.(string) }(struct{}{})
+}
+
+func handledError(c *gin.Context) {
+	if _, err := os.Open("nonexistent_file.txt"); err != nil {
+		bugsnag.Notify(err, c.Request.Context())
+	}
+}
+
+func metadata(c *gin.Context) {
+	customerData := map[string]string{"Name": "Joe Bloggs", "Age": "21"}
+	bugsnag.Notify(fmt.Errorf("oops"), bugsnag.MetaData{
+		"Scheme": {
+			"Customer": customerData,
+			"Level":    "Blue",
+		},
+	})
+}
+
+func dontdie(c *gin.Context) {
+	defer bugsnag.Recover()
+	func(a interface{}) string { return a.(string) }(struct{}{})
+}
+
+func async(c *gin.Context) {
+	bugsnag.Notify(fmt.Errorf("If I show up it means I was sent synchronously"))
+	defer os.Exit(0)
+}
+
+func user(c *gin.Context) {
+	bugsnag.Notify(fmt.Errorf("oops"), bugsnag.User{
+		Id:    "test-user-id",
+		Name:  "test-user-name",
+		Email: "test-user-email",
+	})
+}
+
+func onbeforenotify(c *gin.Context) {
+	bugsnag.OnBeforeNotify(
+		func(event *bugsnag.Event, config *bugsnag.Configuration) error {
+			if event.Message == "Ignore this error" {
+				return fmt.Errorf("not sending errors to ignore")
+			}
+			// continue notifying as normal
+			if event.Message == "Change error message" {
+				event.Message = "Error message was changed"
+			}
+			return nil
+		})
+	bugsnag.Notify(fmt.Errorf("Ignore this error"))
+	bugsnag.Notify(fmt.Errorf("Don't ignore this error"))
+	bugsnag.Notify(fmt.Errorf("Change error message"))
+}

--- a/features/fixtures/gin/run.sh
+++ b/features/fixtures/gin/run.sh
@@ -1,0 +1,7 @@
+#/bin/sh
+
+set -e
+
+cd $GOPATH/src/github.com/bugsnag/bugsnag-go/features/fixtures/gin
+go build
+./gin

--- a/features/fixtures/martini/main.go
+++ b/features/fixtures/martini/main.go
@@ -57,6 +57,7 @@ func main() {
 	m.Get("/onbeforenotify", onbeforenotify)
 	m.Get("/recover", dontdie)
 	m.Get("/async", async)
+	m.Get("/user", user)
 
 	m.RunOnAddr(":9030")
 }
@@ -90,6 +91,14 @@ func dontdie() {
 func async() {
 	bugsnag.Notify(fmt.Errorf("If I show up it means I was sent synchronously"))
 	defer os.Exit(0)
+}
+
+func user() {
+	bugsnag.Notify(fmt.Errorf("oops"), bugsnag.User{
+		Id:    "test-user-id",
+		Name:  "test-user-name",
+		Email: "test-user-email",
+	})
 }
 
 func onbeforenotify() {

--- a/features/fixtures/martini/main.go
+++ b/features/fixtures/martini/main.go
@@ -56,6 +56,7 @@ func main() {
 	m.Get("/metadata", metadata)
 	m.Get("/onbeforenotify", onbeforenotify)
 	m.Get("/recover", dontdie)
+	m.Get("/async", async)
 
 	m.RunOnAddr(":9030")
 }
@@ -84,6 +85,11 @@ func metadata() {
 func dontdie() {
 	defer bugsnag.Recover()
 	func(a interface{}) string { return a.(string) }(struct{}{})
+}
+
+func async() {
+	bugsnag.Notify(fmt.Errorf("If I show up it means I was sent synchronously"))
+	defer os.Exit(0)
 }
 
 func onbeforenotify() {

--- a/features/fixtures/martini/main.go
+++ b/features/fixtures/martini/main.go
@@ -55,6 +55,7 @@ func main() {
 	m.Get("/handled", performHandledError)
 	m.Get("/metadata", metadata)
 	m.Get("/onbeforenotify", onbeforenotify)
+	m.Get("/recover", dontdie)
 
 	m.RunOnAddr(":9030")
 }
@@ -78,6 +79,11 @@ func metadata() {
 			"Level":    "Blue",
 		},
 	})
+}
+
+func dontdie() {
+	defer bugsnag.Recover()
+	func(a interface{}) string { return a.(string) }(struct{}{})
 }
 
 func onbeforenotify() {

--- a/features/fixtures/martini/main.go
+++ b/features/fixtures/martini/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -52,6 +53,7 @@ func main() {
 
 	m.Get("/unhandled", performUnhandledCrash)
 	m.Get("/handled", performHandledError)
+	m.Get("/metadata", metadata)
 
 	m.RunOnAddr(":9030")
 }
@@ -65,4 +67,14 @@ func performHandledError(r *http.Request) {
 	if _, err := os.Open("nonexistent_file.txt"); err != nil {
 		bugsnag.Notify(err, r.Context())
 	}
+}
+
+func metadata() {
+	customerData := map[string]string{"Name": "Joe Bloggs", "Age": "21"}
+	bugsnag.Notify(fmt.Errorf("oops"), true, bugsnag.MetaData{
+		"Scheme": {
+			"Customer": customerData,
+			"Level":    "Blue",
+		},
+	})
 }

--- a/features/fixtures/martini/main.go
+++ b/features/fixtures/martini/main.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/bugsnag/bugsnag-go"
+	"github.com/bugsnag/bugsnag-go/martini"
+	"github.com/go-martini/martini"
+)
+
+func main() {
+	m := martini.Classic()
+
+	if os.Getenv("DISABLE_REPORT_PAYLOADS") != "" {
+		// Increase publish rate for testing
+		bugsnag.DefaultSessionPublishInterval = time.Millisecond * 20
+	}
+
+	config := bugsnag.Configuration{
+		AppVersion: os.Getenv("APP_VERSION"),
+		AppType:    os.Getenv("APP_TYPE"),
+		APIKey:     os.Getenv("API_KEY"),
+		Endpoint:   os.Getenv("ENDPOINT"),
+		Endpoints: bugsnag.Endpoints{
+			Notify:   os.Getenv("NOTIFY_ENDPOINT"),
+			Sessions: os.Getenv("SESSIONS_ENDPOINT"),
+		},
+		Hostname:     os.Getenv("HOSTNAME"),
+		ReleaseStage: os.Getenv("RELEASE_STAGE"),
+	}
+
+	if stages := os.Getenv("NOTIFY_RELEASE_STAGES"); stages != "" {
+		config.NotifyReleaseStages = []string{stages}
+	}
+
+	if filters := os.Getenv("PARAMS_FILTERS"); filters != "" {
+		config.ParamsFilters = []string{filters}
+	}
+
+	config.Synchronous, _ = strconv.ParseBool(os.Getenv("SYNCHRONOUS"))
+	bugsnag.Configure(config)
+
+	m.Use(martini.Recovery())
+	m.Use(bugsnagmartini.AutoNotify())
+
+	m.Get("/unhandled", performUnhandledCrash)
+	m.Get("/handled", performHandledError)
+
+	m.RunOnAddr(":9030")
+}
+
+func performUnhandledCrash() {
+	// Invalid type assertion, will panic
+	func(a interface{}) string { return a.(string) }(struct{}{})
+}
+
+func performHandledError(r *http.Request) {
+	if _, err := os.Open("nonexistent_file.txt"); err != nil {
+		bugsnag.Notify(err, r.Context())
+	}
+}

--- a/features/fixtures/martini/main.go
+++ b/features/fixtures/martini/main.go
@@ -36,6 +36,10 @@ func main() {
 		config.NotifyReleaseStages = []string{stages}
 	}
 
+	if acs, _ := strconv.ParseBool(os.Getenv("AUTO_CAPTURE_SESSIONS")); acs {
+		config.AutoCaptureSessions = acs
+	}
+
 	if filters := os.Getenv("PARAMS_FILTERS"); filters != "" {
 		config.ParamsFilters = []string{filters}
 	}

--- a/features/fixtures/martini/run.sh
+++ b/features/fixtures/martini/run.sh
@@ -1,0 +1,7 @@
+#/bin/sh
+
+set -e
+
+cd $GOPATH/src/github.com/bugsnag/bugsnag-go/features/fixtures/martini
+go build
+./martini

--- a/features/fixtures/negroni/main.go
+++ b/features/fixtures/negroni/main.go
@@ -60,9 +60,6 @@ func main() {
 }
 
 func unhandledCrash(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(200)
-	w.Write([]byte("OK\n"))
-
 	// Invalid type assertion, will panic
 	func(a interface{}) string { return a.(string) }(struct{}{})
 }

--- a/features/fixtures/negroni/main.go
+++ b/features/fixtures/negroni/main.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/bugsnag/bugsnag-go"
+	"github.com/bugsnag/bugsnag-go/negroni"
+	"github.com/urfave/negroni"
+)
+
+func main() {
+	config := bugsnag.Configuration{
+		AppVersion: os.Getenv("APP_VERSION"),
+		AppType:    os.Getenv("APP_TYPE"),
+		APIKey:     os.Getenv("API_KEY"),
+		Endpoint:   os.Getenv("ENDPOINT"),
+		Endpoints: bugsnag.Endpoints{
+			Notify:   os.Getenv("NOTIFY_ENDPOINT"),
+			Sessions: os.Getenv("SESSIONS_ENDPOINT"),
+		},
+		Hostname:     os.Getenv("HOSTNAME"),
+		ReleaseStage: os.Getenv("RELEASE_STAGE"),
+	}
+
+	if stages := os.Getenv("NOTIFY_RELEASE_STAGES"); stages != "" {
+		config.NotifyReleaseStages = []string{stages}
+	}
+
+	if acs, _ := strconv.ParseBool(os.Getenv("AUTO_CAPTURE_SESSIONS")); acs {
+		config.AutoCaptureSessions = acs
+	}
+
+	if filters := os.Getenv("PARAMS_FILTERS"); filters != "" {
+		config.ParamsFilters = []string{filters}
+
+	}
+
+	config.Synchronous, _ = strconv.ParseBool(os.Getenv("SYNCHRONOUS"))
+	bugsnag.Configure(config)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/unhandled", unhandledCrash)
+	mux.HandleFunc("/handled", handledError)
+	mux.HandleFunc("/metadata", metadata)
+	mux.HandleFunc("/onbeforenotify", onbeforenotify)
+	mux.HandleFunc("/recover", dontdie)
+	mux.HandleFunc("/async", async)
+	mux.HandleFunc("/user", user)
+
+	n := negroni.New()
+	n.Use(negroni.NewRecovery())
+	// Add bugsnag handler after negroni.NewRecovery() to ensure panics get picked up
+	n.Use(bugsnagnegroni.AutoNotify())
+	n.UseHandler(mux)
+
+	http.ListenAndServe(":9040", n)
+}
+
+func unhandledCrash(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(200)
+	w.Write([]byte("OK\n"))
+
+	// Invalid type assertion, will panic
+	func(a interface{}) string { return a.(string) }(struct{}{})
+}
+
+func handledError(w http.ResponseWriter, r *http.Request) {
+	if _, err := os.Open("nonexistent_file.txt"); err != nil {
+		bugsnag.Notify(err, r.Context())
+	}
+}
+
+func metadata(w http.ResponseWriter, r *http.Request) {
+	customerData := map[string]string{"Name": "Joe Bloggs", "Age": "21"}
+	bugsnag.Notify(fmt.Errorf("oops"), bugsnag.MetaData{
+		"Scheme": {
+			"Customer": customerData,
+			"Level":    "Blue",
+		},
+	})
+}
+
+func dontdie(w http.ResponseWriter, r *http.Request) {
+	defer bugsnag.Recover()
+	func(a interface{}) string { return a.(string) }(struct{}{})
+}
+
+func async(w http.ResponseWriter, r *http.Request) {
+	bugsnag.Notify(fmt.Errorf("If I show up it means I was sent synchronously"))
+	defer os.Exit(0)
+}
+
+func user(w http.ResponseWriter, r *http.Request) {
+	bugsnag.Notify(fmt.Errorf("oops"), bugsnag.User{
+		Id:    "test-user-id",
+		Name:  "test-user-name",
+		Email: "test-user-email",
+	})
+}
+
+func onbeforenotify(w http.ResponseWriter, r *http.Request) {
+	bugsnag.OnBeforeNotify(
+		func(event *bugsnag.Event, config *bugsnag.Configuration) error {
+			if event.Message == "Ignore this error" {
+				return fmt.Errorf("not sending errors to ignore")
+			}
+			// continue notifying as normal
+			if event.Message == "Change error message" {
+				event.Message = "Error message was changed"
+			}
+			return nil
+		})
+	bugsnag.Notify(fmt.Errorf("Ignore this error"))
+	bugsnag.Notify(fmt.Errorf("Don't ignore this error"))
+	bugsnag.Notify(fmt.Errorf("Change error message"))
+}

--- a/features/fixtures/negroni/run.sh
+++ b/features/fixtures/negroni/run.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-cd $GOPATH/src/github.com/bugsnag/bugsnag-go/features/fixtures/martini
+cd $GOPATH/src/github.com/bugsnag/bugsnag-go/features/fixtures/negroni
 go build
 ./negroni

--- a/features/fixtures/negroni/run.sh
+++ b/features/fixtures/negroni/run.sh
@@ -1,0 +1,7 @@
+#/bin/sh
+
+set -e
+
+cd $GOPATH/src/github.com/bugsnag/bugsnag-go/features/fixtures/martini
+go build
+./negroni

--- a/features/gin/apptype.feature
+++ b/features/gin/apptype.feature
@@ -1,0 +1,12 @@
+Feature: Configuring app type
+
+Scenario: A gin error report contains the configured app type
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "APP_TYPE" to "background-queue"
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "app.type" equals "background-queue"

--- a/features/gin/appversion.feature
+++ b/features/gin/appversion.feature
@@ -1,0 +1,12 @@
+Feature: Configuring app version
+
+Scenario: A gin error report contains the configured app version
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "APP_VERSION" to "1.3.56"
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "app.version" equals "1.3.56"

--- a/features/gin/autocapturesessions.feature
+++ b/features/gin/autocapturesessions.feature
@@ -1,0 +1,11 @@
+Feature: Configure auto capture sessions
+
+Scenario: Disabling auto capture sessions for gin
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag endpoints
+  And I set environment variable "AUTO_CAPTURE_SESSIONS" to "false"
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"

--- a/features/gin/autonotify.feature
+++ b/features/gin/autonotify.feature
@@ -1,0 +1,11 @@
+Feature: Using auto notify
+
+Scenario: An error report is sent when a gin request panics
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/unhandled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is true

--- a/features/gin/endpoint.feature
+++ b/features/gin/endpoint.feature
@@ -1,0 +1,10 @@
+Feature: Configuring endpoint
+
+Scenario: An error report is sent when a gin is configured to use the legacy endpoint
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I set the legacy endpoint only
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"

--- a/features/gin/handled.feature
+++ b/features/gin/handled.feature
@@ -1,0 +1,11 @@
+Feature: Plain handled errors
+
+Scenario: An error report is sent when a gin request sends off a handled error
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is false

--- a/features/gin/hostname.feature
+++ b/features/gin/hostname.feature
@@ -1,0 +1,12 @@
+Feature: Configuring hostname
+
+Scenario: A gin error report contains the configured hostname
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "HOSTNAME" to "server-24"
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "device.hostname" equals "server-24"

--- a/features/gin/metadata.feature
+++ b/features/gin/metadata.feature
@@ -1,0 +1,13 @@
+Feature: Sending meta data
+
+Scenario: An error report can add metadata for gin
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/metadata"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "metaData.Scheme.Customer.Name" equals "Joe Bloggs"
+  And the event "metaData.Scheme.Customer.Age" equals "21"
+  And the event "metaData.Scheme.Level" equals "Blue"

--- a/features/gin/onbeforenotify.feature
+++ b/features/gin/onbeforenotify.feature
@@ -1,0 +1,13 @@
+Feature: Configuring on before notify
+
+Scenario: A gin error report contains the configured hostname
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  Given I set environment variable "SYNCHRONOUS" to "true"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/onbeforenotify"
+  Then I should receive 2 requests
+  And the "bugsnag-api-key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 0
+  And the "bugsnag-api-key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 1
+  And the payload field "events.0.exceptions.0.message" equals "Don't ignore this error" for request 0
+  And the payload field "events.0.exceptions.0.message" equals "Error message was changed" for request 1

--- a/features/gin/paramfilters.feature
+++ b/features/gin/paramfilters.feature
@@ -1,0 +1,12 @@
+Feature: Configuring param filters
+
+Scenario: Filtering metadata for gin apps
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  Given I set environment variable "PARAMS_FILTERS" to "Name"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/metadata"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "metaData.Scheme.Customer.Name" equals "[FILTERED]"

--- a/features/gin/recover.feature
+++ b/features/gin/recover.feature
@@ -1,0 +1,13 @@
+Feature: Using recover
+
+Scenario: Recovering for gin apps
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/recover"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is false
+  And the exception "errorClass" equals "*runtime.TypeAssertionError"
+  And the exception "message" equals "interface conversion: interface {} is struct {}, not string"

--- a/features/gin/releasestage.feature
+++ b/features/gin/releasestage.feature
@@ -1,0 +1,42 @@
+Feature: Configuring release stages and notify release stages
+
+Scenario: An error report is sent when release stage matches notify release stages for gin
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "RELEASE_STAGE" to "staging"
+  And I set environment variable "NOTIFY_RELEASE_STAGES" to "staging"
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
+Scenario: An error report is sent when no notify release stages are specified for gin
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "RELEASE_STAGE" to "staging"
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
+Scenario: An error report is sent regardless of notify release stages if release stage is not set for gin
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "NOTIFY_RELEASE_STAGES" to "staging"
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
+Scenario: An error report is not sent if the release stage does not match the notify release stages for gin
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "RELEASE_STAGE" to "staging"
+  And I set environment variable "NOTIFY_RELEASE_STAGES" to "production"
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/handled"
+  And I wait for 1 second
+  Then I should receive no requests

--- a/features/gin/request.feature
+++ b/features/gin/request.feature
@@ -1,0 +1,11 @@
+Feature: Capturing request information automatically
+
+Scenario: A gin error report will automatically contain request information
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "request.httpMethod" equals "GET"

--- a/features/gin/sessioncontext.feature
+++ b/features/gin/sessioncontext.feature
@@ -1,0 +1,11 @@
+Feature: Session data inside an error report using a session context
+
+Scenario: An error report contains a session count when part of a session for gin
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the payload field "events.0.session.events.handled" equals 1 for request 0

--- a/features/gin/synchronous.feature
+++ b/features/gin/synchronous.feature
@@ -1,0 +1,22 @@
+Feature: Configuring synchronous flag
+
+Scenario: An error report is report synchronously so it will send before exiting
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  Given I set environment variable "SYNCHRONOUS" to "true"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/gin/run.sh"
+  And I wait for 1 second
+  And I send a request to '/async' on the gin app that might fail
+  And I wait for 1 second
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
+Scenario: An error report is sent asynchrously but exits immediately so is not sent for gin
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/gin/run.sh"
+  And I wait for 1 second
+  And I send a request to '/async' on the gin app that might fail
+  And I wait for 1 second
+  Then I should receive no requests

--- a/features/gin/user.feature
+++ b/features/gin/user.feature
@@ -1,0 +1,13 @@
+Feature: Sending user data
+
+Scenario: An error report contains custom user data for gin
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/gin/run.sh"
+  And I go to the gin route "/user"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "user.id" equals "test-user-id"
+  And the event "user.name" equals "test-user-name"
+  And the event "user.email" equals "test-user-email"

--- a/features/handled.feature
+++ b/features/handled.feature
@@ -1,27 +1,5 @@
 Feature: Plain handled errors
 
-Scenario: An error report is sent when a negroni request sends off a handled error
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new negroni app
-  And I configure the bugsnag notify endpoint only
-  When I run the script "features/fixtures/negroni/run.sh"
-  And I go to the negroni route "/handled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "unhandled" is false
-
-Scenario: An error report is sent when a martini request sends off a handled error
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
-  And I configure the bugsnag notify endpoint only
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/handled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "unhandled" is false
-
 Scenario: A handled error sends a report
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/handled.feature
+++ b/features/handled.feature
@@ -1,5 +1,16 @@
 Feature: Plain handled errors
 
+Scenario: An error report is sent when a martini request sends off a handled error
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is false
+
 Scenario: A handled error sends a report
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/handled.feature
+++ b/features/handled.feature
@@ -1,5 +1,16 @@
 Feature: Plain handled errors
 
+Scenario: An error report is sent when a negroni request sends off a handled error
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is false
+
 Scenario: An error report is sent when a martini request sends off a handled error
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I am working with a new martini app

--- a/features/hostname.feature
+++ b/features/hostname.feature
@@ -1,29 +1,5 @@
 Feature: Configuring hostname
 
-Scenario: A negroni error report contains the configured hostname
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new negroni app
-  And I configure the bugsnag notify endpoint only
-  And I set environment variable "HOSTNAME" to "server-24"
-  When I run the script "features/fixtures/negroni/run.sh"
-  And I go to the negroni route "/handled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "device.hostname" equals "server-24"
-
-Scenario: A martini error report contains the configured hostname
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
-  And I configure the bugsnag notify endpoint only
-  And I set environment variable "HOSTNAME" to "server-24"
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/handled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "device.hostname" equals "server-24"
-
 Scenario: An error report contains the configured hostname
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/hostname.feature
+++ b/features/hostname.feature
@@ -1,5 +1,17 @@
 Feature: Configuring hostname
 
+Scenario: A martini error report contains the configured hostname
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "HOSTNAME" to "server-24"
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "device.hostname" equals "server-24"
+
 Scenario: An error report contains the configured hostname
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/hostname.feature
+++ b/features/hostname.feature
@@ -1,5 +1,17 @@
 Feature: Configuring hostname
 
+Scenario: A negroni error report contains the configured hostname
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "HOSTNAME" to "server-24"
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "device.hostname" equals "server-24"
+
 Scenario: A martini error report contains the configured hostname
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I am working with a new martini app

--- a/features/martini/apptype.feature
+++ b/features/martini/apptype.feature
@@ -2,7 +2,6 @@ Feature: Configuring app type
 
 Scenario: A martini error report contains the configured app type
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
   And I configure the bugsnag notify endpoint only
   And I set environment variable "APP_TYPE" to "background-queue"
   When I run the script "features/fixtures/martini/run.sh"

--- a/features/martini/apptype.feature
+++ b/features/martini/apptype.feature
@@ -1,0 +1,15 @@
+Feature: Configuring app type
+
+Scenario: A martini error report contains the configured app type
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "APP_TYPE" to "background-queue"
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "app.type" equals "background-queue"
+
+

--- a/features/martini/appversion.feature
+++ b/features/martini/appversion.feature
@@ -2,7 +2,6 @@ Feature: Configuring app version
 
 Scenario: A martini error report contains the configured app version
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
   And I configure the bugsnag notify endpoint only
   And I set environment variable "APP_VERSION" to "1.3.56"
   When I run the script "features/fixtures/martini/run.sh"

--- a/features/martini/appversion.feature
+++ b/features/martini/appversion.feature
@@ -1,0 +1,13 @@
+Feature: Configuring app version
+
+Scenario: A martini error report contains the configured app version
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "APP_VERSION" to "1.3.56"
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "app.version" equals "1.3.56"

--- a/features/martini/autocapturesessions.feature
+++ b/features/martini/autocapturesessions.feature
@@ -1,0 +1,13 @@
+Feature: Configure auto capture sessions
+
+Scenario: Disabling auto capture sessions for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag endpoints
+  And I set environment variable "AUTO_CAPTURE_SESSIONS" to "false"
+  When I run the script "features/fixtures/martini/run.sh"
+  And I wait for 1 second
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"

--- a/features/martini/autocapturesessions.feature
+++ b/features/martini/autocapturesessions.feature
@@ -2,7 +2,6 @@ Feature: Configure auto capture sessions
 
 Scenario: Disabling auto capture sessions for martini
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
   And I configure the bugsnag endpoints
   And I set environment variable "AUTO_CAPTURE_SESSIONS" to "false"
   When I run the script "features/fixtures/martini/run.sh"

--- a/features/martini/autonotify.feature
+++ b/features/martini/autonotify.feature
@@ -1,0 +1,12 @@
+Feature: Using auto notify
+
+Scenario: An error report is sent when a martini request panics
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/unhandled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is true

--- a/features/martini/autonotify.feature
+++ b/features/martini/autonotify.feature
@@ -2,7 +2,6 @@ Feature: Using auto notify
 
 Scenario: An error report is sent when a martini request panics
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
   And I configure the bugsnag notify endpoint only
   When I run the script "features/fixtures/martini/run.sh"
   And I go to the martini route "/unhandled"

--- a/features/martini/endpoint.feature
+++ b/features/martini/endpoint.feature
@@ -1,0 +1,11 @@
+Feature: Configuring endpoint
+
+Scenario: An error report is sent when a martini is configured to use the legacy endpoint
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I set the legacy endpoint only
+  And I am working with a new martini app
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"

--- a/features/martini/endpoint.feature
+++ b/features/martini/endpoint.feature
@@ -3,7 +3,6 @@ Feature: Configuring endpoint
 Scenario: An error report is sent when a martini is configured to use the legacy endpoint
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I set the legacy endpoint only
-  And I am working with a new martini app
   When I run the script "features/fixtures/martini/run.sh"
   And I go to the martini route "/handled"
   Then I should receive a request

--- a/features/martini/handled.feature
+++ b/features/martini/handled.feature
@@ -1,0 +1,12 @@
+Feature: Plain handled errors
+
+Scenario: An error report is sent when a martini request sends off a handled error
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is false

--- a/features/martini/handled.feature
+++ b/features/martini/handled.feature
@@ -2,7 +2,6 @@ Feature: Plain handled errors
 
 Scenario: An error report is sent when a martini request sends off a handled error
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
   And I configure the bugsnag notify endpoint only
   When I run the script "features/fixtures/martini/run.sh"
   And I go to the martini route "/handled"

--- a/features/martini/hostname.feature
+++ b/features/martini/hostname.feature
@@ -1,0 +1,13 @@
+Feature: Configuring hostname
+
+Scenario: A martini error report contains the configured hostname
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "HOSTNAME" to "server-24"
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "device.hostname" equals "server-24"

--- a/features/martini/hostname.feature
+++ b/features/martini/hostname.feature
@@ -2,7 +2,6 @@ Feature: Configuring hostname
 
 Scenario: A martini error report contains the configured hostname
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
   And I configure the bugsnag notify endpoint only
   And I set environment variable "HOSTNAME" to "server-24"
   When I run the script "features/fixtures/martini/run.sh"

--- a/features/martini/metadata.feature
+++ b/features/martini/metadata.feature
@@ -1,0 +1,14 @@
+Feature: Sending meta data
+
+Scenario: An error report can add metadata for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/metadata"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "metaData.Scheme.Customer.Name" equals "Joe Bloggs"
+  And the event "metaData.Scheme.Customer.Age" equals "21"
+  And the event "metaData.Scheme.Level" equals "Blue"

--- a/features/martini/metadata.feature
+++ b/features/martini/metadata.feature
@@ -2,7 +2,6 @@ Feature: Sending meta data
 
 Scenario: An error report can add metadata for martini
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
   And I configure the bugsnag notify endpoint only
   When I run the script "features/fixtures/martini/run.sh"
   And I go to the martini route "/metadata"

--- a/features/martini/onbeforenotify.feature
+++ b/features/martini/onbeforenotify.feature
@@ -1,0 +1,14 @@
+Feature: Configuring on before notify
+
+Scenario: A martini error report contains the configured hostname
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  Given I set environment variable "SYNCHRONOUS" to "true"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/onbeforenotify"
+  Then I should receive 2 requests
+  And the "bugsnag-api-key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 0
+  And the "bugsnag-api-key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 1
+  And the payload field "events.0.exceptions.0.message" equals "Don't ignore this error" for request 0
+  And the payload field "events.0.exceptions.0.message" equals "Error message was changed" for request 1

--- a/features/martini/onbeforenotify.feature
+++ b/features/martini/onbeforenotify.feature
@@ -3,7 +3,6 @@ Feature: Configuring on before notify
 Scenario: A martini error report contains the configured hostname
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   Given I set environment variable "SYNCHRONOUS" to "true"
-  And I am working with a new martini app
   And I configure the bugsnag notify endpoint only
   When I run the script "features/fixtures/martini/run.sh"
   And I go to the martini route "/onbeforenotify"

--- a/features/martini/paramfilters.feature
+++ b/features/martini/paramfilters.feature
@@ -3,7 +3,6 @@ Feature: Configuring param filters
 Scenario: Filtering metadata for martini apps
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   Given I set environment variable "PARAMS_FILTERS" to "Name"
-  And I am working with a new martini app
   And I configure the bugsnag notify endpoint only
   When I run the script "features/fixtures/martini/run.sh"
   And I go to the martini route "/metadata"

--- a/features/martini/paramfilters.feature
+++ b/features/martini/paramfilters.feature
@@ -1,0 +1,13 @@
+Feature: Configuring param filters
+
+Scenario: Filtering metadata for martini apps
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  Given I set environment variable "PARAMS_FILTERS" to "Name"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/metadata"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "metaData.Scheme.Customer.Name" equals "[FILTERED]"

--- a/features/martini/recover.feature
+++ b/features/martini/recover.feature
@@ -1,0 +1,14 @@
+Feature: Using recover
+
+Scenario: Recovering metadata for martini apps
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/recover"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is false
+  And the exception "errorClass" equals "*runtime.TypeAssertionError"
+  And the exception "message" equals "interface conversion: interface {} is struct {}, not string"

--- a/features/martini/recover.feature
+++ b/features/martini/recover.feature
@@ -2,7 +2,6 @@ Feature: Using recover
 
 Scenario: Recovering metadata for martini apps
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
   And I configure the bugsnag notify endpoint only
   When I run the script "features/fixtures/martini/run.sh"
   And I go to the martini route "/recover"

--- a/features/martini/releasestage.feature
+++ b/features/martini/releasestage.feature
@@ -1,0 +1,46 @@
+Feature: Configuring release stages and notify release stages
+
+Scenario: An error report is sent when release stage matches notify release stages for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "RELEASE_STAGE" to "staging"
+  And I set environment variable "NOTIFY_RELEASE_STAGES" to "staging"
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
+Scenario: An error report is sent when no notify release stages are specified for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "RELEASE_STAGE" to "staging"
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
+Scenario: An error report is sent regardless of notify release stages if release stage is not set for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "NOTIFY_RELEASE_STAGES" to "staging"
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
+Scenario: An error report is not sent if the release stage does not match the notify release stages for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "RELEASE_STAGE" to "staging"
+  And I set environment variable "NOTIFY_RELEASE_STAGES" to "production"
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  And I wait for 1 second
+  Then I should receive no requests

--- a/features/martini/releasestage.feature
+++ b/features/martini/releasestage.feature
@@ -2,7 +2,6 @@ Feature: Configuring release stages and notify release stages
 
 Scenario: An error report is sent when release stage matches notify release stages for martini
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
   And I configure the bugsnag notify endpoint only
   And I set environment variable "RELEASE_STAGE" to "staging"
   And I set environment variable "NOTIFY_RELEASE_STAGES" to "staging"
@@ -14,7 +13,6 @@ Scenario: An error report is sent when release stage matches notify release stag
 
 Scenario: An error report is sent when no notify release stages are specified for martini
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
   And I configure the bugsnag notify endpoint only
   And I set environment variable "RELEASE_STAGE" to "staging"
   When I run the script "features/fixtures/martini/run.sh"
@@ -25,7 +23,6 @@ Scenario: An error report is sent when no notify release stages are specified fo
 
 Scenario: An error report is sent regardless of notify release stages if release stage is not set for martini
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
   And I configure the bugsnag notify endpoint only
   And I set environment variable "NOTIFY_RELEASE_STAGES" to "staging"
   When I run the script "features/fixtures/martini/run.sh"
@@ -36,7 +33,6 @@ Scenario: An error report is sent regardless of notify release stages if release
 
 Scenario: An error report is not sent if the release stage does not match the notify release stages for martini
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
   And I configure the bugsnag notify endpoint only
   And I set environment variable "RELEASE_STAGE" to "staging"
   And I set environment variable "NOTIFY_RELEASE_STAGES" to "production"

--- a/features/martini/request.feature
+++ b/features/martini/request.feature
@@ -1,0 +1,12 @@
+Feature: Capturing request information automatically
+
+Scenario: A martini error report will automatically contain request information
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "request.httpMethod" equals "GET"

--- a/features/martini/request.feature
+++ b/features/martini/request.feature
@@ -2,7 +2,6 @@ Feature: Capturing request information automatically
 
 Scenario: A martini error report will automatically contain request information
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
   And I configure the bugsnag notify endpoint only
   When I run the script "features/fixtures/martini/run.sh"
   And I go to the martini route "/handled"

--- a/features/martini/sessioncontext.feature
+++ b/features/martini/sessioncontext.feature
@@ -2,7 +2,6 @@ Feature: Session data inside an error report using a session context
 
 Scenario: An error report contains a session count when part of a session for martini
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
   And I configure the bugsnag notify endpoint only
   When I run the script "features/fixtures/martini/run.sh"
   And I go to the martini route "/handled"

--- a/features/martini/sessioncontext.feature
+++ b/features/martini/sessioncontext.feature
@@ -1,0 +1,12 @@
+Feature: Session data inside an error report using a session context
+
+Scenario: An error report contains a session count when part of a session for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the payload field "events.0.session.events.handled" equals 1 for request 0

--- a/features/martini/synchronous.feature
+++ b/features/martini/synchronous.feature
@@ -1,0 +1,11 @@
+Feature: Configuring synchronous flag
+
+Scenario: An error report is sent asynchrously but exits immediately so is not sent for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I wait for 1 second
+  And I send a request to '/async' on the martini app that might fail
+  And I wait for 1 second
+  Then I should receive no requests

--- a/features/martini/synchronous.feature
+++ b/features/martini/synchronous.feature
@@ -2,7 +2,6 @@ Feature: Configuring synchronous flag
 
 Scenario: An error report is sent asynchrously but exits immediately so is not sent for martini
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
   And I configure the bugsnag notify endpoint only
   When I run the script "features/fixtures/martini/run.sh"
   And I wait for 1 second

--- a/features/martini/synchronous.feature
+++ b/features/martini/synchronous.feature
@@ -1,5 +1,17 @@
 Feature: Configuring synchronous flag
 
+Scenario: An error report is report synchronously so it will send before exiting
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  Given I set environment variable "SYNCHRONOUS" to "true"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I wait for 1 second
+  And I send a request to '/async' on the martini app that might fail
+  And I wait for 1 second
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
 Scenario: An error report is sent asynchrously but exits immediately so is not sent for martini
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag notify endpoint only

--- a/features/martini/user.feature
+++ b/features/martini/user.feature
@@ -1,6 +1,6 @@
 Feature: Sending user data
 
-:Scenario => An error report contains custom user data for martini
+Scenario: An error report contains custom user data for martini
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag notify endpoint only
   When I run the script "features/fixtures/martini/run.sh"

--- a/features/martini/user.feature
+++ b/features/martini/user.feature
@@ -1,8 +1,7 @@
 Feature: Sending user data
 
-Scenario: An error report contains custom user data for martini
+:Scenario => An error report contains custom user data for martini
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
   And I configure the bugsnag notify endpoint only
   When I run the script "features/fixtures/martini/run.sh"
   And I go to the martini route "/user"

--- a/features/martini/user.feature
+++ b/features/martini/user.feature
@@ -1,0 +1,14 @@
+Feature: Sending user data
+
+Scenario: An error report contains custom user data for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/user"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "user.id" equals "test-user-id"
+  And the event "user.name" equals "test-user-name"
+  And the event "user.email" equals "test-user-email"

--- a/features/metadata.feature
+++ b/features/metadata.feature
@@ -1,31 +1,5 @@
 Feature: Sending meta data
 
-Scenario: An error report can add metadata for negroni
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new negroni app
-  And I configure the bugsnag notify endpoint only
-  When I run the script "features/fixtures/negroni/run.sh"
-  And I go to the negroni route "/metadata"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "metaData.Scheme.Customer.Name" equals "Joe Bloggs"
-  And the event "metaData.Scheme.Customer.Age" equals "21"
-  And the event "metaData.Scheme.Level" equals "Blue"
-
-Scenario: An error report can add metadata for martini
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
-  And I configure the bugsnag notify endpoint only
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/metadata"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "metaData.Scheme.Customer.Name" equals "Joe Bloggs"
-  And the event "metaData.Scheme.Customer.Age" equals "21"
-  And the event "metaData.Scheme.Level" equals "Blue"
-
 Scenario: An error report contains custom meta data
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/metadata.feature
+++ b/features/metadata.feature
@@ -1,5 +1,18 @@
 Feature: Sending meta data
 
+Scenario: An error report can add metadata for negroni
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/metadata"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "metaData.Scheme.Customer.Name" equals "Joe Bloggs"
+  And the event "metaData.Scheme.Customer.Age" equals "21"
+  And the event "metaData.Scheme.Level" equals "Blue"
+
 Scenario: An error report can add metadata for martini
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I am working with a new martini app

--- a/features/metadata.feature
+++ b/features/metadata.feature
@@ -1,5 +1,18 @@
 Feature: Sending meta data
 
+Scenario: An error report can add metadata for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/metadata"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "metaData.Scheme.Customer.Name" equals "Joe Bloggs"
+  And the event "metaData.Scheme.Customer.Age" equals "21"
+  And the event "metaData.Scheme.Level" equals "Blue"
+
 Scenario: An error report contains custom meta data
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/negroni/apptype.feature
+++ b/features/negroni/apptype.feature
@@ -2,7 +2,6 @@ Feature: Configuring app type
 
 Scenario: A negroni error report contains the configured app type
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new negroni app
   And I configure the bugsnag notify endpoint only
   And I set environment variable "APP_TYPE" to "background-queue"
   When I run the script "features/fixtures/negroni/run.sh"

--- a/features/negroni/apptype.feature
+++ b/features/negroni/apptype.feature
@@ -1,0 +1,13 @@
+Feature: Configuring app type
+
+Scenario: A negroni error report contains the configured app type
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "APP_TYPE" to "background-queue"
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "app.type" equals "background-queue"

--- a/features/negroni/appversion.feature
+++ b/features/negroni/appversion.feature
@@ -1,0 +1,13 @@
+Feature: Configuring app version
+
+Scenario: A negroni error report contains the configured app version
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "APP_VERSION" to "1.3.56"
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "app.version" equals "1.3.56"

--- a/features/negroni/appversion.feature
+++ b/features/negroni/appversion.feature
@@ -2,7 +2,6 @@ Feature: Configuring app version
 
 Scenario: A negroni error report contains the configured app version
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new negroni app
   And I configure the bugsnag notify endpoint only
   And I set environment variable "APP_VERSION" to "1.3.56"
   When I run the script "features/fixtures/negroni/run.sh"

--- a/features/negroni/autocapturesessions.feature
+++ b/features/negroni/autocapturesessions.feature
@@ -2,7 +2,6 @@ Feature: Configure auto capture sessions
 
 Scenario: Disabling auto capture sessions for negroni
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new negroni app
   And I configure the bugsnag endpoints
   And I set environment variable "AUTO_CAPTURE_SESSIONS" to "false"
   When I run the script "features/fixtures/negroni/run.sh"

--- a/features/negroni/autocapturesessions.feature
+++ b/features/negroni/autocapturesessions.feature
@@ -1,0 +1,12 @@
+Feature: Configure auto capture sessions
+
+Scenario: Disabling auto capture sessions for negroni
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new negroni app
+  And I configure the bugsnag endpoints
+  And I set environment variable "AUTO_CAPTURE_SESSIONS" to "false"
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"

--- a/features/negroni/autonotify.feature
+++ b/features/negroni/autonotify.feature
@@ -1,0 +1,12 @@
+Feature: Using auto notify
+
+Scenario: An error report is sent when a negroni request panics
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/unhandled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is true

--- a/features/negroni/autonotify.feature
+++ b/features/negroni/autonotify.feature
@@ -2,7 +2,6 @@ Feature: Using auto notify
 
 Scenario: An error report is sent when a negroni request panics
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new negroni app
   And I configure the bugsnag notify endpoint only
   When I run the script "features/fixtures/negroni/run.sh"
   And I go to the negroni route "/unhandled"

--- a/features/negroni/endpoint.feature
+++ b/features/negroni/endpoint.feature
@@ -1,0 +1,11 @@
+Feature: Configuring endpoint
+
+Scenario: An error report is sent when a negroni is configured to use the legacy endpoint
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I set the legacy endpoint only
+  And I am working with a new negroni app
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"

--- a/features/negroni/endpoint.feature
+++ b/features/negroni/endpoint.feature
@@ -3,7 +3,6 @@ Feature: Configuring endpoint
 Scenario: An error report is sent when a negroni is configured to use the legacy endpoint
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I set the legacy endpoint only
-  And I am working with a new negroni app
   When I run the script "features/fixtures/negroni/run.sh"
   And I go to the negroni route "/handled"
   Then I should receive a request

--- a/features/negroni/handled.feature
+++ b/features/negroni/handled.feature
@@ -1,0 +1,12 @@
+Feature: Plain handled errors
+
+Scenario: An error report is sent when a negroni request sends off a handled error
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is false

--- a/features/negroni/handled.feature
+++ b/features/negroni/handled.feature
@@ -2,7 +2,6 @@ Feature: Plain handled errors
 
 Scenario: An error report is sent when a negroni request sends off a handled error
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new negroni app
   And I configure the bugsnag notify endpoint only
   When I run the script "features/fixtures/negroni/run.sh"
   And I go to the negroni route "/handled"

--- a/features/negroni/hostname.feature
+++ b/features/negroni/hostname.feature
@@ -2,7 +2,6 @@ Feature: Configuring hostname
 
 Scenario: A negroni error report contains the configured hostname
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new negroni app
   And I configure the bugsnag notify endpoint only
   And I set environment variable "HOSTNAME" to "server-24"
   When I run the script "features/fixtures/negroni/run.sh"

--- a/features/negroni/hostname.feature
+++ b/features/negroni/hostname.feature
@@ -1,0 +1,13 @@
+Feature: Configuring hostname
+
+Scenario: A negroni error report contains the configured hostname
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "HOSTNAME" to "server-24"
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "device.hostname" equals "server-24"

--- a/features/negroni/metadata.feature
+++ b/features/negroni/metadata.feature
@@ -2,7 +2,6 @@ Feature: Sending meta data
 
 Scenario: An error report can add metadata for negroni
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new negroni app
   And I configure the bugsnag notify endpoint only
   When I run the script "features/fixtures/negroni/run.sh"
   And I go to the negroni route "/metadata"

--- a/features/negroni/metadata.feature
+++ b/features/negroni/metadata.feature
@@ -1,0 +1,14 @@
+Feature: Sending meta data
+
+Scenario: An error report can add metadata for negroni
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/metadata"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "metaData.Scheme.Customer.Name" equals "Joe Bloggs"
+  And the event "metaData.Scheme.Customer.Age" equals "21"
+  And the event "metaData.Scheme.Level" equals "Blue"

--- a/features/negroni/onbeforenotify.feature
+++ b/features/negroni/onbeforenotify.feature
@@ -1,0 +1,14 @@
+Feature: Configuring on before notify
+
+Scenario: A negroni error report contains the configured hostname
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  Given I set environment variable "SYNCHRONOUS" to "true"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/onbeforenotify"
+  Then I should receive 2 requests
+  And the "bugsnag-api-key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 0
+  And the "bugsnag-api-key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 1
+  And the payload field "events.0.exceptions.0.message" equals "Don't ignore this error" for request 0
+  And the payload field "events.0.exceptions.0.message" equals "Error message was changed" for request 1

--- a/features/negroni/onbeforenotify.feature
+++ b/features/negroni/onbeforenotify.feature
@@ -3,7 +3,6 @@ Feature: Configuring on before notify
 Scenario: A negroni error report contains the configured hostname
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   Given I set environment variable "SYNCHRONOUS" to "true"
-  And I am working with a new negroni app
   And I configure the bugsnag notify endpoint only
   When I run the script "features/fixtures/negroni/run.sh"
   And I go to the negroni route "/onbeforenotify"

--- a/features/negroni/paramfilters.feature
+++ b/features/negroni/paramfilters.feature
@@ -1,0 +1,13 @@
+Feature: Configuring param filters
+
+Scenario: Filtering metadata for negroni apps
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  Given I set environment variable "PARAMS_FILTERS" to "Name"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/metadata"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "metaData.Scheme.Customer.Name" equals "[FILTERED]"

--- a/features/negroni/paramfilters.feature
+++ b/features/negroni/paramfilters.feature
@@ -3,7 +3,6 @@ Feature: Configuring param filters
 Scenario: Filtering metadata for negroni apps
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   Given I set environment variable "PARAMS_FILTERS" to "Name"
-  And I am working with a new negroni app
   And I configure the bugsnag notify endpoint only
   When I run the script "features/fixtures/negroni/run.sh"
   And I go to the negroni route "/metadata"

--- a/features/negroni/recover.feature
+++ b/features/negroni/recover.feature
@@ -2,7 +2,6 @@ Feature: Using recover
 
 Scenario: Recovering for negroni apps
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new negroni app
   And I configure the bugsnag notify endpoint only
   When I run the script "features/fixtures/negroni/run.sh"
   And I go to the negroni route "/recover"

--- a/features/negroni/recover.feature
+++ b/features/negroni/recover.feature
@@ -1,0 +1,14 @@
+Feature: Using recover
+
+Scenario: Recovering for negroni apps
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/recover"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is false
+  And the exception "errorClass" equals "*runtime.TypeAssertionError"
+  And the exception "message" equals "interface conversion: interface {} is struct {}, not string"

--- a/features/negroni/releasestage.feature
+++ b/features/negroni/releasestage.feature
@@ -1,1 +1,42 @@
 Feature: Configuring release stages and notify release stages
+
+Scenario: An error report is sent when release stage matches notify release stages for negroni
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "RELEASE_STAGE" to "staging"
+  And I set environment variable "NOTIFY_RELEASE_STAGES" to "staging"
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
+Scenario: An error report is sent when no notify release stages are specified for negroni
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "RELEASE_STAGE" to "staging"
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
+Scenario: An error report is sent regardless of notify release stages if release stage is not set for negroni
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "NOTIFY_RELEASE_STAGES" to "staging"
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
+Scenario: An error report is not sent if the release stage does not match the notify release stages for negroni
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "RELEASE_STAGE" to "staging"
+  And I set environment variable "NOTIFY_RELEASE_STAGES" to "production"
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  And I wait for 1 second
+  Then I should receive no requests

--- a/features/negroni/releasestage.feature
+++ b/features/negroni/releasestage.feature
@@ -1,0 +1,1 @@
+Feature: Configuring release stages and notify release stages

--- a/features/negroni/request.feature
+++ b/features/negroni/request.feature
@@ -1,0 +1,1 @@
+Feature: Capturing request information automatically

--- a/features/negroni/request.feature
+++ b/features/negroni/request.feature
@@ -1,1 +1,11 @@
 Feature: Capturing request information automatically
+
+Scenario: A negroni error report will automatically contain request information
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "request.httpMethod" equals "GET"

--- a/features/negroni/sessioncontext.feature
+++ b/features/negroni/sessioncontext.feature
@@ -1,1 +1,11 @@
 Feature: Session data inside an error report using a session context
+
+Scenario: An error report contains a session count when part of a session for negroni
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the payload field "events.0.session.events.handled" equals 1 for request 0

--- a/features/negroni/sessioncontext.feature
+++ b/features/negroni/sessioncontext.feature
@@ -1,0 +1,1 @@
+Feature: Session data inside an error report using a session context

--- a/features/negroni/synchronous.feature
+++ b/features/negroni/synchronous.feature
@@ -1,0 +1,1 @@
+Feature: Configuring synchronous flag

--- a/features/negroni/synchronous.feature
+++ b/features/negroni/synchronous.feature
@@ -1,1 +1,22 @@
 Feature: Configuring synchronous flag
+
+Scenario: An error report is report synchronously so it will send before exiting
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  Given I set environment variable "SYNCHRONOUS" to "true"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I wait for 1 second
+  And I send a request to '/async' on the negroni app that might fail
+  And I wait for 1 second
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
+Scenario: An error report is sent asynchrously but exits immediately so is not sent for negroni
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I wait for 1 second
+  And I send a request to '/async' on the negroni app that might fail
+  And I wait for 1 second
+  Then I should receive no requests

--- a/features/negroni/user.feature
+++ b/features/negroni/user.feature
@@ -1,0 +1,1 @@
+Feature: Sending user data

--- a/features/negroni/user.feature
+++ b/features/negroni/user.feature
@@ -1,1 +1,13 @@
 Feature: Sending user data
+
+Scenario: An error report contains custom user data for negroni
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/user"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "user.id" equals "test-user-id"
+  And the event "user.name" equals "test-user-name"
+  And the event "user.email" equals "test-user-email"

--- a/features/onbeforenotify.feature
+++ b/features/onbeforenotify.feature
@@ -1,31 +1,5 @@
 Feature: Configuring on before notify
 
-Scenario: A negroni error report contains the configured hostname
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  Given I set environment variable "SYNCHRONOUS" to "true"
-  And I am working with a new negroni app
-  And I configure the bugsnag notify endpoint only
-  When I run the script "features/fixtures/negroni/run.sh"
-  And I go to the negroni route "/onbeforenotify"
-  Then I should receive 2 requests
-  And the "bugsnag-api-key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 0
-  And the "bugsnag-api-key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 1
-  And the payload field "events.0.exceptions.0.message" equals "Don't ignore this error" for request 0
-  And the payload field "events.0.exceptions.0.message" equals "Error message was changed" for request 1
-
-Scenario: A martini error report contains the configured hostname
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  Given I set environment variable "SYNCHRONOUS" to "true"
-  And I am working with a new martini app
-  And I configure the bugsnag notify endpoint only
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/onbeforenotify"
-  Then I should receive 2 requests
-  And the "bugsnag-api-key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 0
-  And the "bugsnag-api-key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 1
-  And the payload field "events.0.exceptions.0.message" equals "Don't ignore this error" for request 0
-  And the payload field "events.0.exceptions.0.message" equals "Error message was changed" for request 1
-
 Scenario: Send three bugsnags and use on before notify to drop one and modify the message of another
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/onbeforenotify.feature
+++ b/features/onbeforenotify.feature
@@ -1,5 +1,18 @@
 Feature: Configuring on before notify
 
+Scenario: A negroni error report contains the configured hostname
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  Given I set environment variable "SYNCHRONOUS" to "true"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/onbeforenotify"
+  Then I should receive 2 requests
+  And the "bugsnag-api-key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 0
+  And the "bugsnag-api-key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 1
+  And the payload field "events.0.exceptions.0.message" equals "Don't ignore this error" for request 0
+  And the payload field "events.0.exceptions.0.message" equals "Error message was changed" for request 1
+
 Scenario: A martini error report contains the configured hostname
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   Given I set environment variable "SYNCHRONOUS" to "true"

--- a/features/onbeforenotify.feature
+++ b/features/onbeforenotify.feature
@@ -1,5 +1,18 @@
 Feature: Configuring on before notify
 
+Scenario: A martini error report contains the configured hostname
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  Given I set environment variable "SYNCHRONOUS" to "true"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/onbeforenotify"
+  Then I should receive 2 requests
+  And the "bugsnag-api-key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 0
+  And the "bugsnag-api-key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 1
+  And the payload field "events.0.exceptions.0.message" equals "Don't ignore this error" for request 0
+  And the payload field "events.0.exceptions.0.message" equals "Error message was changed" for request 1
+
 Scenario: Send three bugsnags and use on before notify to drop one and modify the message of another
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/paramfilters.feature
+++ b/features/paramfilters.feature
@@ -1,29 +1,5 @@
 Feature: Configuring param filters
 
-Scenario: Filtering metadata for negroni apps
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  Given I set environment variable "PARAMS_FILTERS" to "Name"
-  And I am working with a new negroni app
-  And I configure the bugsnag notify endpoint only
-  When I run the script "features/fixtures/negroni/run.sh"
-  And I go to the negroni route "/metadata"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "metaData.Scheme.Customer.Name" equals "[FILTERED]"
-
-Scenario: Filtering metadata for martini apps
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  Given I set environment variable "PARAMS_FILTERS" to "Name"
-  And I am working with a new martini app
-  And I configure the bugsnag notify endpoint only
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/metadata"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "metaData.Scheme.Customer.Name" equals "[FILTERED]"
-
 Scenario: An error report containing meta data is not filtered when the param filters are set but do not match
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/paramfilters.feature
+++ b/features/paramfilters.feature
@@ -1,5 +1,17 @@
 Feature: Configuring param filters
 
+Scenario: Filtering metadata for martini apps
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  Given I set environment variable "PARAMS_FILTERS" to "Name"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/metadata"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "metaData.Scheme.Customer.Name" equals "[FILTERED]"
+
 Scenario: An error report containing meta data is not filtered when the param filters are set but do not match
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/paramfilters.feature
+++ b/features/paramfilters.feature
@@ -1,5 +1,17 @@
 Feature: Configuring param filters
 
+Scenario: Filtering metadata for negroni apps
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  Given I set environment variable "PARAMS_FILTERS" to "Name"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/metadata"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "metaData.Scheme.Customer.Name" equals "[FILTERED]"
+
 Scenario: Filtering metadata for martini apps
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   Given I set environment variable "PARAMS_FILTERS" to "Name"

--- a/features/recover.feature
+++ b/features/recover.feature
@@ -1,6 +1,19 @@
 Feature: Using recover
 
-Scenario: Filtering metadata for martini apps
+Scenario: Recovering for negroni apps
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new negroni app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/negroni/run.sh"
+  And I go to the negroni route "/recover"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is false
+  And the exception "errorClass" equals "*runtime.TypeAssertionError"
+  And the exception "message" equals "interface conversion: interface {} is struct {}, not string"
+
+Scenario: Recovering metadata for martini apps
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I am working with a new martini app
   And I configure the bugsnag notify endpoint only

--- a/features/recover.feature
+++ b/features/recover.feature
@@ -1,31 +1,5 @@
 Feature: Using recover
 
-Scenario: Recovering for negroni apps
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new negroni app
-  And I configure the bugsnag notify endpoint only
-  When I run the script "features/fixtures/negroni/run.sh"
-  And I go to the negroni route "/recover"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "unhandled" is false
-  And the exception "errorClass" equals "*runtime.TypeAssertionError"
-  And the exception "message" equals "interface conversion: interface {} is struct {}, not string"
-
-Scenario: Recovering metadata for martini apps
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
-  And I configure the bugsnag notify endpoint only
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/recover"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "unhandled" is false
-  And the exception "errorClass" equals "*runtime.TypeAssertionError"
-  And the exception "message" equals "interface conversion: interface {} is struct {}, not string"
-
 Scenario: An error report is sent when a go routine crashes
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/recover.feature
+++ b/features/recover.feature
@@ -1,5 +1,18 @@
 Feature: Using recover
 
+Scenario: Filtering metadata for martini apps
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/recover"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is false
+  And the exception "errorClass" equals "*runtime.TypeAssertionError"
+  And the exception "message" equals "interface conversion: interface {} is struct {}, not string"
+
 Scenario: An error report is sent when a go routine crashes
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/releasestage.feature
+++ b/features/releasestage.feature
@@ -1,50 +1,5 @@
 Feature: Configuring release stages and notify release stages
 
-Scenario: An error report is sent when release stage matches notify release stages for martini
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
-  And I configure the bugsnag notify endpoint only
-  And I set environment variable "RELEASE_STAGE" to "staging"
-  And I set environment variable "NOTIFY_RELEASE_STAGES" to "staging"
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/handled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-
-Scenario: An error report is sent when no notify release stages are specified for martini
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
-  And I configure the bugsnag notify endpoint only
-  And I set environment variable "RELEASE_STAGE" to "staging"
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/handled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-
-Scenario: An error report is sent regardless of notify release stages if release stage is not set for martini
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
-  And I configure the bugsnag notify endpoint only
-  And I set environment variable "NOTIFY_RELEASE_STAGES" to "staging"
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/handled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-
-Scenario: An error report is not sent if the release stage does not match the notify release stages for martini
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
-  And I configure the bugsnag notify endpoint only
-  And I set environment variable "RELEASE_STAGE" to "staging"
-  And I set environment variable "NOTIFY_RELEASE_STAGES" to "production"
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/handled"
-  And I wait for 1 second
-  Then I should receive no requests
-
 Scenario: An error report is sent when release stage matches notify release stages
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/releasestage.feature
+++ b/features/releasestage.feature
@@ -1,5 +1,50 @@
 Feature: Configuring release stages and notify release stages
 
+Scenario: An error report is sent when release stage matches notify release stages for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "RELEASE_STAGE" to "staging"
+  And I set environment variable "NOTIFY_RELEASE_STAGES" to "staging"
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
+Scenario: An error report is sent when no notify release stages are specified for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "RELEASE_STAGE" to "staging"
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
+Scenario: An error report is sent regardless of notify release stages if release stage is not set for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "NOTIFY_RELEASE_STAGES" to "staging"
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
+Scenario: An error report is not sent if the release stage does not match the notify release stages for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  And I set environment variable "RELEASE_STAGE" to "staging"
+  And I set environment variable "NOTIFY_RELEASE_STAGES" to "production"
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  And I wait for 1 second
+  Then I should receive no requests
+
 Scenario: An error report is sent when release stage matches notify release stages
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/request.feature
+++ b/features/request.feature
@@ -1,5 +1,16 @@
 Feature: Capturing request information automatically
 
+Scenario: A martini error report will automatically contain request information
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "request.httpMethod" equals "GET"
+
 Scenario: An error report will automatically contain request information
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/request.feature
+++ b/features/request.feature
@@ -1,16 +1,5 @@
 Feature: Capturing request information automatically
 
-Scenario: A martini error report will automatically contain request information
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
-  And I configure the bugsnag notify endpoint only
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/handled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "request.httpMethod" equals "GET"
-
 Scenario: An error report will automatically contain request information
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/sessioncontext.feature
+++ b/features/sessioncontext.feature
@@ -1,5 +1,16 @@
 Feature: Session data inside an error report using a session context
 
+Scenario: An error report contains a session count when part of a session for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/handled"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the payload field "events.0.session.events.handled" equals 1 for request 0
+
 Scenario: An error report contains a session count when part of a session
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/sessioncontext.feature
+++ b/features/sessioncontext.feature
@@ -1,16 +1,5 @@
 Feature: Session data inside an error report using a session context
 
-Scenario: An error report contains a session count when part of a session for martini
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
-  And I configure the bugsnag notify endpoint only
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/handled"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the payload field "events.0.session.events.handled" equals 1 for request 0
-
 Scenario: An error report contains a session count when part of a session
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/steps/gin_steps.rb
+++ b/features/steps/gin_steps.rb
@@ -1,0 +1,15 @@
+GIN_PORT = 9050
+
+When('I go to the gin route {string}') do |route|
+  steps %(
+    And I wait for 1 second
+    And I open the URL "http://localhost:#{GIN_PORT}#{route}"
+    And I wait for 1 second
+  )
+end
+
+When('I send a request to {string} on the gin app that might fail') do |path|
+  run_command(@script_env,
+              "curl http://localhost:#{GIN_PORT}#{path}",
+              must_pass: false)
+end

--- a/features/steps/go_steps.rb
+++ b/features/steps/go_steps.rb
@@ -52,3 +52,9 @@ Then("the request contained the api key {string}") do |api_key|
     And the payload field "apiKey" equals "#{api_key}"
   }
 end
+
+When('I set the legacy endpoint only') do
+  steps %(
+    When I set environment variable "ENDPOINT" to "http://localhost:#{MOCK_API_PORT}"
+  )
+end

--- a/features/steps/martini_steps.rb
+++ b/features/steps/martini_steps.rb
@@ -1,0 +1,13 @@
+MARTINI_PORT = 9030
+
+When('I go to the martini route {string}') do |route|
+  steps %(
+    And I wait for 1 second
+    And I open the URL "http://localhost:#{MARTINI_PORT}#{route}"
+    And I wait for 1 second
+  )
+end
+
+When('I am working with a new martini app') do
+  run_command('killall martini || true')
+end

--- a/features/steps/martini_steps.rb
+++ b/features/steps/martini_steps.rb
@@ -8,12 +8,6 @@ When('I go to the martini route {string}') do |route|
   )
 end
 
-When('I set the legacy endpoint only') do
-  steps %Q{
-    When I set environment variable "ENDPOINT" to "http://localhost:#{MOCK_API_PORT}"
-  }
-end
-
 When('I am working with a new martini app') do
   run_command('killall martini || true')
 end

--- a/features/steps/martini_steps.rb
+++ b/features/steps/martini_steps.rb
@@ -9,7 +9,10 @@ When('I go to the martini route {string}') do |route|
 end
 
 When('I am working with a new martini app') do
-  run_command('killall martini || true')
+  begin
+    run_command('killall martini || true')
+  rescue SignalException
+  end
 end
 
 When('I send a request to {string} on the martini app that might fail') do |path|

--- a/features/steps/martini_steps.rb
+++ b/features/steps/martini_steps.rb
@@ -8,13 +8,6 @@ When('I go to the martini route {string}') do |route|
   )
 end
 
-When('I am working with a new martini app') do
-  begin
-    run_command('killall martini || true')
-  rescue SignalException
-  end
-end
-
 When('I send a request to {string} on the martini app that might fail') do |path|
   run_command(@script_env,
               "curl http://localhost:#{MARTINI_PORT}#{path}",

--- a/features/steps/martini_steps.rb
+++ b/features/steps/martini_steps.rb
@@ -17,3 +17,9 @@ end
 When('I am working with a new martini app') do
   run_command('killall martini || true')
 end
+
+When('I send a request to {string} on the martini app that might fail') do |path|
+  run_command(@script_env,
+              "curl http://localhost:#{MARTINI_PORT}#{path}",
+              must_pass: false)
+end

--- a/features/steps/martini_steps.rb
+++ b/features/steps/martini_steps.rb
@@ -8,6 +8,12 @@ When('I go to the martini route {string}') do |route|
   )
 end
 
+When('I set the legacy endpoint only') do
+  steps %Q{
+    When I set environment variable "ENDPOINT" to "http://localhost:#{MOCK_API_PORT}"
+  }
+end
+
 When('I am working with a new martini app') do
   run_command('killall martini || true')
 end

--- a/features/steps/negroni_steps.rb
+++ b/features/steps/negroni_steps.rb
@@ -1,0 +1,25 @@
+NEGRONI_PORT = 9030
+
+When('I go to the negroni route {string}') do |route|
+  steps %(
+    And I wait for 1 second
+    And I open the URL "http://localhost:#{NEGRONI_PORT}#{route}"
+    And I wait for 1 second
+  )
+end
+
+When('I set the legacy endpoint only') do
+  steps %(
+    When I set environment variable "ENDPOINT" to "http://localhost:#{MOCK_API_PORT}"
+  )
+end
+
+When('I am working with a new negroni app') do
+  run_command('killall negroni || true')
+end
+
+When('I send a request to {string} on the negroni app that might fail') do |path|
+  run_command(@script_env,
+              "curl http://localhost:#{NEGRONI_PORT}#{path}",
+              must_pass: false)
+end

--- a/features/steps/negroni_steps.rb
+++ b/features/steps/negroni_steps.rb
@@ -1,4 +1,4 @@
-NEGRONI_PORT = 9030
+NEGRONI_PORT = 9040
 
 When('I go to the negroni route {string}') do |route|
   steps %(
@@ -9,7 +9,10 @@ When('I go to the negroni route {string}') do |route|
 end
 
 When('I am working with a new negroni app') do
-  run_command('killall negroni || true')
+  begin
+    run_command('killall negroni || true')
+  rescue SignalException
+  end
 end
 
 When('I send a request to {string} on the negroni app that might fail') do |path|

--- a/features/steps/negroni_steps.rb
+++ b/features/steps/negroni_steps.rb
@@ -8,13 +8,6 @@ When('I go to the negroni route {string}') do |route|
   )
 end
 
-When('I am working with a new negroni app') do
-  begin
-    run_command('killall negroni || true')
-  rescue SignalException
-  end
-end
-
 When('I send a request to {string} on the negroni app that might fail') do |path|
   run_command(@script_env,
               "curl http://localhost:#{NEGRONI_PORT}#{path}",

--- a/features/steps/negroni_steps.rb
+++ b/features/steps/negroni_steps.rb
@@ -8,12 +8,6 @@ When('I go to the negroni route {string}') do |route|
   )
 end
 
-When('I set the legacy endpoint only') do
-  steps %(
-    When I set environment variable "ENDPOINT" to "http://localhost:#{MOCK_API_PORT}"
-  )
-end
-
 When('I am working with a new negroni app') do
   run_command('killall negroni || true')
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,22 @@
+Before do
+  kill_apps
+end
+
+After do
+  kill_apps
+end
+
+def kill_apps
+    begin
+      run_command('killall martini || true')
+    rescue SignalException
+    end
+    begin
+      run_command('killall negroni || true')
+    rescue SignalException
+    end
+    begin
+      run_command('killall revel || true')
+    rescue SignalException
+    end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,16 +7,11 @@ After do
 end
 
 def kill_apps
+  %w[gin martini revel negroni].each do |framework|
     begin
-      run_command('killall martini || true')
+      run_command("killall #{framework} || true")
     rescue SignalException
+      # This can be raised in cases where the app isn't running
     end
-    begin
-      run_command('killall negroni || true')
-    rescue SignalException
-    end
-    begin
-      run_command('killall revel || true')
-    rescue SignalException
-    end
+  end
 end

--- a/features/synchronous.feature
+++ b/features/synchronous.feature
@@ -1,18 +1,5 @@
 Feature: Configuring synchronous flag
 
-Scenario: An error report is report synchronously so it will send before exiting
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
-  Given I set environment variable "SYNCHRONOUS" to "true"
-  And I configure the bugsnag notify endpoint only
-  When I run the script "features/fixtures/martini/run.sh"
-  And I wait for 1 second
-  And I send a request to '/async' on the martini app that might fail
-  And I wait for 1 second
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-
 Scenario: An error report is sent asynchrously but exits immediately so is not sent
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/synchronous.feature
+++ b/features/synchronous.feature
@@ -1,5 +1,28 @@
 Feature: Configuring synchronous flag
 
+Scenario: An error report is sent asynchrously but exits immediately so is not sent for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I wait for 1 second
+  And I send a request to '/async' on the martini app that might fail
+  And I wait for 1 second
+  Then I should receive no requests
+
+Scenario: An error report is report synchronously so it will send before exiting
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  Given I set environment variable "SYNCHRONOUS" to "true"
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I wait for 1 second
+  And I send a request to '/async' on the martini app that might fail
+  And I wait for 1 second
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
 Scenario: An error report is sent asynchrously but exits immediately so is not sent
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/synchronous.feature
+++ b/features/synchronous.feature
@@ -1,15 +1,5 @@
 Feature: Configuring synchronous flag
 
-Scenario: An error report is sent asynchrously but exits immediately so is not sent for martini
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
-  And I configure the bugsnag notify endpoint only
-  When I run the script "features/fixtures/martini/run.sh"
-  And I wait for 1 second
-  And I send a request to '/async' on the martini app that might fail
-  And I wait for 1 second
-  Then I should receive no requests
-
 Scenario: An error report is report synchronously so it will send before exiting
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I am working with a new martini app

--- a/features/user.feature
+++ b/features/user.feature
@@ -1,5 +1,19 @@
 Feature: Sending user data
 
+Scenario: An error report contains custom user data for martini
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I am working with a new martini app
+  And I configure the bugsnag notify endpoint only
+  When I run the script "features/fixtures/martini/run.sh"
+  And I go to the martini route "/user"
+  Then I should receive a request
+  And the request used payload v4 headers
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "user.id" equals "test-user-id"
+  And the event "user.name" equals "test-user-name"
+  And the event "user.email" equals "test-user-email"
+
+
 Scenario: An error report contains custom user data
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints

--- a/features/user.feature
+++ b/features/user.feature
@@ -1,19 +1,5 @@
 Feature: Sending user data
 
-Scenario: An error report contains custom user data for martini
-  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And I am working with a new martini app
-  And I configure the bugsnag notify endpoint only
-  When I run the script "features/fixtures/martini/run.sh"
-  And I go to the martini route "/user"
-  Then I should receive a request
-  And the request used payload v4 headers
-  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event "user.id" equals "test-user-id"
-  And the event "user.name" equals "test-user-name"
-  And the event "user.email" equals "test-user-email"
-
-
 Scenario: An error report contains custom user data
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And I configure the bugsnag endpoints
@@ -28,7 +14,6 @@ Scenario: An error report contains custom user data
   And the event "user.id" equals "test-user-id"
   And the event "user.name" equals "test-user-name"
   And the event "user.email" equals "test-user-email"
-
 
 Scenario: An error report contains custom user data when using net http
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"


### PR DESCRIPTION
Changed the approach from keeping all the features in the same file regardless of frameworks to keeping the frameworks in their own folder. This made developing a lot faster, and might even have affected stability.

I'm going to close #88 in favour of this one FYI @Cawllec 

It seems to be pretty flakey on CI - but it appears to be running pretty consistently locally.