### PR TITLE
Dedupe crash count in session

### DIFF
--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -56,7 +56,7 @@ func (t *testSessionTracker) StartSession(context.Context) context.Context {
 	return context.Background()
 }
 
-func (t *testSessionTracker) GetSession(context.Context, bool) *sessions.Session {
+func (t *testSessionTracker) IncrementEventCountAndGetSession(context.Context, bool) *sessions.Session {
 	return &sessions.Session{}
 }
 

--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -56,7 +56,7 @@ func (t *testSessionTracker) StartSession(context.Context) context.Context {
 	return context.Background()
 }
 
-func (t *testSessionTracker) GetSession(context.Context) *sessions.Session {
+func (t *testSessionTracker) GetSession(context.Context, bool) *sessions.Session {
 	return &sessions.Session{}
 }
 
@@ -119,7 +119,7 @@ func TestNotify(t *testing.T) {
 		Context:        "testing",
 		Device:         &deviceJSON{Hostname: "web1"},
 		GroupingHash:   "lol",
-		Session:        &sessionJSON{Events: eventCountsJSON{Handled: 0, Unhandled: 1}},
+		Session:        &sessionJSON{Events: sessions.EventCounts{Handled: 0, Unhandled: 1}},
 		Severity:       "warning",
 		SeverityReason: &severityReasonJSON{Type: SeverityReasonHandledError},
 		Unhandled:      false,
@@ -199,7 +199,7 @@ func TestHandlerFunc(t *testing.T) {
 			Context:        "/unhandled",
 			Device:         &deviceJSON{Hostname: "web1"},
 			GroupingHash:   "",
-			Session:        &sessionJSON{Events: eventCountsJSON{Handled: 0, Unhandled: 1}},
+			Session:        &sessionJSON{Events: sessions.EventCounts{Handled: 0, Unhandled: 1}},
 			Severity:       "error",
 			SeverityReason: &severityReasonJSON{Type: SeverityReasonHandledPanic},
 			Unhandled:      true,
@@ -238,7 +238,7 @@ func TestHandlerFunc(t *testing.T) {
 			Context:        "/handled",
 			Device:         &deviceJSON{Hostname: "web1"},
 			GroupingHash:   "",
-			Session:        &sessionJSON{Events: eventCountsJSON{Handled: 1, Unhandled: 0}},
+			Session:        &sessionJSON{Events: sessions.EventCounts{Handled: 1, Unhandled: 0}},
 			Severity:       "warning",
 			SeverityReason: &severityReasonJSON{Type: SeverityReasonHandledError},
 			Unhandled:      false,
@@ -297,7 +297,7 @@ func TestHandler(t *testing.T) {
 		Context:        "/ok",
 		Device:         &deviceJSON{Hostname: "web1"},
 		GroupingHash:   "",
-		Session:        &sessionJSON{Events: eventCountsJSON{Handled: 0, Unhandled: 1}},
+		Session:        &sessionJSON{Events: sessions.EventCounts{Handled: 0, Unhandled: 1}},
 		Severity:       "info",
 		SeverityReason: &severityReasonJSON{Type: SeverityReasonHandledPanic},
 		Unhandled:      true,
@@ -364,7 +364,7 @@ func TestAutoNotify(t *testing.T) {
 		Context:        "",
 		Device:         &deviceJSON{Hostname: "web1"},
 		GroupingHash:   "",
-		Session:        &sessionJSON{Events: eventCountsJSON{Handled: 0, Unhandled: 1}},
+		Session:        &sessionJSON{Events: sessions.EventCounts{Handled: 0, Unhandled: 1}},
 		Severity:       "error",
 		SeverityReason: &severityReasonJSON{Type: SeverityReasonHandledPanic},
 		Unhandled:      true,
@@ -403,7 +403,7 @@ func TestRecover(t *testing.T) {
 		Context:        "",
 		Device:         &deviceJSON{Hostname: "web1"},
 		GroupingHash:   "",
-		Session:        &sessionJSON{Events: eventCountsJSON{Handled: 0, Unhandled: 1}},
+		Session:        &sessionJSON{Events: sessions.EventCounts{Handled: 0, Unhandled: 1}},
 		Severity:       "warning",
 		SeverityReason: &severityReasonJSON{Type: SeverityReasonHandledPanic},
 		Unhandled:      false,
@@ -446,7 +446,7 @@ func TestRecoverCustomHandledState(t *testing.T) {
 		Context:        "",
 		Device:         &deviceJSON{Hostname: "web1"},
 		GroupingHash:   "",
-		Session:        &sessionJSON{Events: eventCountsJSON{Handled: 0, Unhandled: 1}},
+		Session:        &sessionJSON{Events: sessions.EventCounts{Handled: 0, Unhandled: 1}},
 		Severity:       "error",
 		SeverityReason: &severityReasonJSON{Type: SeverityReasonHandledPanic},
 		Unhandled:      true,
@@ -473,7 +473,7 @@ func TestSeverityReasonNotifyCallback(t *testing.T) {
 		Context:        "",
 		Device:         &deviceJSON{Hostname: "web1"},
 		GroupingHash:   "",
-		Session:        &sessionJSON{Events: eventCountsJSON{Handled: 0, Unhandled: 1}},
+		Session:        &sessionJSON{Events: sessions.EventCounts{Handled: 0, Unhandled: 1}},
 		Severity:       "info",
 		SeverityReason: &severityReasonJSON{Type: SeverityReasonCallbackSpecified},
 		Unhandled:      false,

--- a/features/plain_features/multieventsession.feature
+++ b/features/plain_features/multieventsession.feature
@@ -1,0 +1,23 @@
+Feature: Reporting multiple handled and unhandled errors in the same session
+
+Background:
+  Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I configure the bugsnag endpoint
+  And I have built the service "app"
+  And I set environment variable "AUTO_CAPTURE_SESSIONS" to "false"
+
+Scenario: Handled errors know about previous reported handled errors
+  When I run the go service "app" with the test case "multiple handled"
+  And I wait to receive 2 requests
+  And the request 0 is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the request 1 is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event handled sessions count equals 1 for request 0
+  And the event handled sessions count equals 2 for request 1
+
+Scenario: Unhandled errors know about previous reported handled errors
+  When I run the go service "app" with the test case "multiple unhandled"
+  And I wait to receive 2 requests
+  And the request 0 is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the request 1 is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event unhandled sessions count equals 1 for request 0
+  And the event unhandled sessions count equals 2 for request 1

--- a/panicwrap_test.go
+++ b/panicwrap_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/bitly/go-simplejson"
+	"github.com/bugsnag/bugsnag-go/sessions"
 	"github.com/kardianos/osext"
 )
 
@@ -31,7 +32,7 @@ func TestPanicHandlerHandledPanic(t *testing.T) {
 		Context:        "",
 		Device:         &deviceJSON{Hostname: "web1"},
 		GroupingHash:   "",
-		Session:        &sessionJSON{Events: eventCountsJSON{Handled: 0, Unhandled: 1}},
+		Session:        &sessionJSON{Events: sessions.EventCounts{Handled: 0, Unhandled: 1}},
 		Severity:       "error",
 		SeverityReason: &severityReasonJSON{Type: SeverityReasonHandledPanic},
 		Unhandled:      true,
@@ -68,7 +69,7 @@ func TestPanicHandlerUnhandledPanic(t *testing.T) {
 		Context:        "",
 		Device:         &deviceJSON{Hostname: "web1"},
 		GroupingHash:   "",
-		Session:        &sessionJSON{Events: eventCountsJSON{Handled: 0, Unhandled: 1}},
+		Session:        &sessionJSON{Events: sessions.EventCounts{Handled: 0, Unhandled: 1}},
 		Severity:       "error",
 		SeverityReason: &severityReasonJSON{Type: SeverityReasonUnhandledPanic},
 		Unhandled:      true,

--- a/payload.go
+++ b/payload.go
@@ -100,7 +100,8 @@ func (p *payload) makeSession() *sessionJSON {
 		return nil
 	}
 
-	if session := sessions.GetSession(p.Ctx, p.handledState.Unhandled); session != nil {
+	session := sessions.IncrementEventCountAndGetSession(p.Ctx, p.handledState.Unhandled)
+	if session != nil {
 		return &sessionJSON{
 			ID:        session.ID,
 			StartedAt: session.StartedAt.UTC().Format(time.RFC3339),

--- a/payload.go
+++ b/payload.go
@@ -94,22 +94,17 @@ func (p *payload) MarshalJSON() ([]byte, error) {
 }
 
 func (p *payload) makeSession() *sessionJSON {
-	handled, unhandled := 1, 0
-	if p.handledState.Unhandled {
-		handled, unhandled = unhandled, handled
-	}
-
 	// If a context has not been applied to the payload then assume that no
 	// session has started either
 	if p.Ctx == nil {
 		return nil
 	}
 
-	if session := sessions.GetSession(p.Ctx); session != nil {
+	if session := sessions.GetSession(p.Ctx, p.handledState.Unhandled); session != nil {
 		return &sessionJSON{
 			ID:        session.ID,
 			StartedAt: session.StartedAt.UTC().Format(time.RFC3339),
-			Events:    eventCountsJSON{Handled: handled, Unhandled: unhandled},
+			Events:    *session.EventCounts,
 		}
 	}
 	return nil

--- a/report.go
+++ b/report.go
@@ -1,6 +1,7 @@
 package bugsnag
 
 import (
+	"github.com/bugsnag/bugsnag-go/sessions"
 	uuid "github.com/gofrs/uuid"
 )
 
@@ -33,14 +34,9 @@ type eventJSON struct {
 }
 
 type sessionJSON struct {
-	StartedAt string          `json:"startedAt"`
-	ID        uuid.UUID       `json:"id"`
-	Events    eventCountsJSON `json:"events"`
-}
-
-type eventCountsJSON struct {
-	Handled   int `json:"handled"`
-	Unhandled int `json:"unhandled"`
+	StartedAt string               `json:"startedAt"`
+	ID        uuid.UUID            `json:"id"`
+	Events    sessions.EventCounts `json:"events"`
 }
 
 type appJSON struct {

--- a/sessions/session.go
+++ b/sessions/session.go
@@ -6,16 +6,25 @@ import (
 	uuid "github.com/gofrs/uuid"
 )
 
+// EventCounts register how many handled/unhandled events have happened for
+// this session
+type EventCounts struct {
+	Handled   int `json:"handled"`
+	Unhandled int `json:"unhandled"`
+}
+
 // Session represents a start time and a unique ID that identifies the session.
 type Session struct {
-	StartedAt time.Time
-	ID        uuid.UUID
+	StartedAt   time.Time
+	ID          uuid.UUID
+	EventCounts *EventCounts
 }
 
 func newSession() *Session {
 	sessionID, _ := uuid.NewV4()
 	return &Session{
-		StartedAt: time.Now(),
-		ID:        sessionID,
+		StartedAt:   time.Now(),
+		ID:          sessionID,
+		EventCounts: &EventCounts{},
 	}
 }

--- a/sessions/tracker.go
+++ b/sessions/tracker.go
@@ -16,8 +16,6 @@ const (
 	contextSessionKey ctxKey = 1
 )
 
-var sessionMutex sync.Mutex
-
 // ctxKey is a type alias that ensures uniqueness as a context.Context key
 type ctxKey int
 
@@ -59,15 +57,12 @@ func IncrementEventCountAndGetSession(ctx context.Context, unhandled bool) *Sess
 	if s := ctx.Value(contextSessionKey); s != nil {
 		if session, ok := s.(*Session); ok && !session.StartedAt.IsZero() {
 			// It is not just getting back a default value
-			sessionMutex.Lock()
-			defer sessionMutex.Unlock()
-			eventCounts := session.EventCounts
+			ec := session.EventCounts
 			if unhandled {
-				eventCounts.Unhandled++
+				ec.Unhandled++
 			} else {
-				eventCounts.Handled++
+				ec.Handled++
 			}
-			*session.EventCounts = *eventCounts
 			return session
 		}
 	}

--- a/sessions/tracker.go
+++ b/sessions/tracker.go
@@ -52,8 +52,10 @@ func NewSessionTracker(config *SessionTrackingConfiguration) SessionTracker {
 	return &st
 }
 
-// GetSession extracts a session from a context
-func GetSession(ctx context.Context, unhandled bool) *Session {
+// IncrementEventCountAndGetSession extracts a Bugsnag session from the given
+// context and increments the event count of unhandled or handled events and
+// returns the session
+func IncrementEventCountAndGetSession(ctx context.Context, unhandled bool) *Session {
 	if s := ctx.Value(contextSessionKey); s != nil {
 		if session, ok := s.(*Session); ok && !session.StartedAt.IsZero() {
 			// It is not just getting back a default value

--- a/sessions/tracker_test.go
+++ b/sessions/tracker_test.go
@@ -39,7 +39,7 @@ func TestStartSessionModifiesContext(t *testing.T) {
 		t.Fatalf("No session information applied to context %v", ctx)
 	}
 
-	verifyValidSession(t, GetSession(ctx))
+	verifyValidSession(t, GetSession(ctx, true))
 }
 
 func TestShouldOnlyWriteWhenReceivingSessions(t *testing.T) {

--- a/sessions/tracker_test.go
+++ b/sessions/tracker_test.go
@@ -39,7 +39,7 @@ func TestStartSessionModifiesContext(t *testing.T) {
 		t.Fatalf("No session information applied to context %v", ctx)
 	}
 
-	verifyValidSession(t, GetSession(ctx, true))
+	verifyValidSession(t, IncrementEventCountAndGetSession(ctx, true))
 }
 
 func TestShouldOnlyWriteWhenReceivingSessions(t *testing.T) {


### PR DESCRIPTION
Ensure that multiple crashes in the same session only counts towards the stability score once by keeping track of how many events have been reported against a single session.

We can count how many handled/unhandled events have happened already through a count in the session struct itself. This was basically identical to the already existing `eventCountsJSON` struct, so I just moved that into the `sessions` package, and changed the references to use that.