### PR TITLE
Martini fixes

### DIFF
--- a/sessions/publisher.go
+++ b/sessions/publisher.go
@@ -36,6 +36,9 @@ func (p *publisher) publish(sessions []*Session) error {
 		// log every minute
 		return nil
 	}
+	if apiKey := p.config.APIKey; len(apiKey) != 32 {
+		return fmt.Errorf("bugsnag/sessions/publisher.publish invalid API key: '%s'", apiKey)
+	}
 	nrs, rs := p.config.NotifyReleaseStages, p.config.ReleaseStage
 	if rs != "" && (nrs != nil && !contains(nrs, rs)) {
 		// Always send sessions if the release stage is not set, but don't send any

--- a/sessions/publisher_test.go
+++ b/sessions/publisher_test.go
@@ -154,6 +154,20 @@ func TestSendsCorrectPayloadForBigConfig(t *testing.T) {
 	}
 }
 
+func TestNoSessionsSentWhenAPIKeyIsMissing(t *testing.T) {
+	sessions, _ := makeSessions()
+	config := makeHeavyConfig()
+	config.APIKey = "labracadabrador"
+	publisher := publisher{config: config, client: &testHTTPClient{}}
+	if err := publisher.publish(sessions); err != nil {
+		if got, exp := err.Error(), "bugsnag/sessions/publisher.publish invalid API key: 'labracadabrador'"; got != exp {
+			t.Errorf(`Expected error message "%s" but got "%s"`, exp, got)
+		}
+	} else {
+		t.Errorf("Expected error message but no errors were returned")
+	}
+}
+
 func TestNoSessionsOutsideNotifyReleaseStages(t *testing.T) {
 	sessions, _ := makeSessions()
 


### PR DESCRIPTION
Ensures that session tracking and correct configuration is applied as expected when only doing a `bugsnagmartini.AutoNotify()` without a `bugsnag.Configure()` first.

As a side effect, this also fixes a bug where the `bugsnag.Notify(err)` call doesn't work when using Bugsnag globally instead of injecting the notifier.

Additionally adds an API key check at the session publisher level, instead of relying on responses from the session server itself.