### PR TITLE
Fix Windows compilation issue

### DIFF
--- a/sessions/tracker.go
+++ b/sessions/tracker.go
@@ -130,7 +130,12 @@ func (s *sessionTracker) flushSessionsAndRepeatSignal(shutdown chan<- os.Signal,
 			s.config.logf("%v", err)
 		}
 	}
-	syscall.Kill(syscall.Getpid(), sig)
+
+	if p, err := os.FindProcess(os.Getpid()); err != nil {
+		s.config.logf("%v", err)
+	} else {
+		p.Signal(sig)
+	}
 }
 
 func (s *sessionTracker) FlushSessions() {


### PR DESCRIPTION
## Goal

Make this package compile on Windows.

## Changeset

There was a call to `syscall.Getpid()` which does not exist on Windows. Change this to instead use `os.FindProcess(os.Getpid())`.

## Tests

I have verified manually that sessions and handled & unhandled events get sent to Bugsnag by trying out the example projects.

### Linked issues

Fixes #96

## Review

For the submitter, initial self-review:

- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
