### PR TITLE
Don't test against Go's master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ jobs:
       go: "1.10"
     - script: make ci
       go: "1.11"
-    - script: make ci
-      go: "master"
 
     - stage: plain go app tests
       script: make testplain


### PR DESCRIPTION
Disable testing of branch and PR builds against Go's latest development
branch. This should be done on a scheduled basis instead, but this
is too strict to prevent PR builds and branch builds from passing.