### PR TITLE
Sanitize request headers like other metadata fields

### DIFF
--- a/request_extractor.go
+++ b/request_extractor.go
@@ -60,7 +60,7 @@ func parseRequestHeaders(header map[string][]string) map[string]string {
 
 func contains(slice []string, e string) bool {
 	for _, s := range slice {
-		if strings.ToLower(s) == strings.ToLower(e) {
+		if strings.Contains(strings.ToLower(e), strings.ToLower(s)) {
 			return true
 		}
 	}

--- a/request_extractor_test.go
+++ b/request_extractor_test.go
@@ -59,6 +59,7 @@ func TestParseHeadersWillSanitiseIllegalParams(t *testing.T) {
 	headers["password"] = []string{"correct horse battery staple"}
 	headers["secret"] = []string{"I am Banksy"}
 	headers["authorization"] = []string{"licence to kill -9"}
+	headers["custom-made-secret"] = []string{"I'm the insider at Sotheby's"}
 	for k, v := range parseRequestHeaders(headers) {
 		if v != "[FILTERED]" {
 			t.Errorf("expected '%s' to be [FILTERED], but was '%s'", k, v)


### PR DESCRIPTION
## Goal

Make sure that all data sanitization using `Config.ParamsFilters` behaves the same. the `ParamsFilters` slice should contain "sensitive substrings", so if a key contains any of the `ParamsFilters`, it should be considered sensitive.

This is already the case in the metadata sanitizer:

https://github.com/bugsnag/bugsnag-go/blob/834d8fee64233ea79b0389ad7a5a438261788f66/metadata.go#L185-L192

## Design

Why was this approach to the goal used?

Use the same `string.Contains` logic also for request headers. Makes sure to filter heades like `Set-Cookie` or `X-Service-Secret`.

## Changeset

### Changed

Changed `request_extractor.contains`.

## Tests

Updated the corresponding test case.

## Discussion

### Alternative Approaches

<!-- What other approaches were considered or discussed? -->

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

### Linked issues

<!--

Fixes #
Related to #

-->

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [x] Consistency across platforms for structures or concepts added or modified
- [x] Consistency between the changeset and the goal stated above
- [x] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [x] Usage friction - is the proposed change in usage cumbersome or complicated?
- [x] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [x] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [x] Thoroughness of added tests and any missing edge cases
- [x] Idiomatic use of the language
