### PR TITLE
Release v1.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ jobs:
       go: "1.10"
     - script: make ci
       go: "1.11"
-    - script: make ci
-      go: "master"
 
     - stage: plain go app tests
       script: make testplain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@
 This release fixes a compilation error on Windows.
 Due to a missing implementation in the Go library, Windows users may have to send two interrupt signals to interrupt the application. Other signals are expected to work as expected.
 
+Additionally, add a fix to make sure data sanitisation behaves the same for both request data and metadata.
+
 ### Bug fixes
 
 * Use the `os` package instead of `syscall` to re-send signals, as `syscall` varies per platform, which caused a compilation error.
+
+* Make sure that all data sanitization using Config.ParamsFilters behaves the same.
+  [#104](https://github.com/bugsnag/bugsnag-go/pull/104)
+  [Adam Renberg Tamm](https://github.com/tgwizard)
 
 ## 1.4.0 (2018-11-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,15 @@
 ## 1.4.1 (2019-03-18)
 
 This release fixes a compilation error on Windows.
-Due to a missing implementation in the Go library, Windows users may have to send two interrupt signals to interrupt the application. Other signals are expected to work as expected.
+Due to a missing implementation in the Go library, Windows users may have to send two interrupt signals to interrupt the application. Other signals are unaffected.
 
-Additionally, add a fix to make sure data sanitisation behaves the same for both request data and metadata.
+Additionally, ensure data sanitisation behaves the same for both request data and metadata.
 
 ### Bug fixes
 
 * Use the `os` package instead of `syscall` to re-send signals, as `syscall` varies per platform, which caused a compilation error.
 
-* Make sure that all data sanitization using Config.ParamsFilters behaves the same.
+* Make sure that all data sanitization using `Config.ParamsFilters` behaves the same.
   [#104](https://github.com/bugsnag/bugsnag-go/pull/104)
   [Adam Renberg Tamm](https://github.com/tgwizard)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.4.1 (2019-03-18)
+
+This release fixes a compilation error on Windows.
+Due to a missing implementation in the Go library, Windows users may have to send two interrupt signals to interrupt the application. Other signals are expected to work as expected.
+
+### Bug fixes
+
+* Use the `os` package instead of `syscall` to re-send signals, as `syscall` varies per platform, which caused a compilation error.
+
 ## 1.4.0 (2018-11-19)
 
 This release is a big non-breaking revamp of the notifier. Most importantly, this release introduces session tracking to Go applications.

--- a/request_extractor.go
+++ b/request_extractor.go
@@ -60,7 +60,7 @@ func parseRequestHeaders(header map[string][]string) map[string]string {
 
 func contains(slice []string, e string) bool {
 	for _, s := range slice {
-		if strings.ToLower(s) == strings.ToLower(e) {
+		if strings.Contains(strings.ToLower(e), strings.ToLower(s)) {
 			return true
 		}
 	}

--- a/request_extractor_test.go
+++ b/request_extractor_test.go
@@ -59,6 +59,7 @@ func TestParseHeadersWillSanitiseIllegalParams(t *testing.T) {
 	headers["password"] = []string{"correct horse battery staple"}
 	headers["secret"] = []string{"I am Banksy"}
 	headers["authorization"] = []string{"licence to kill -9"}
+	headers["custom-made-secret"] = []string{"I'm the insider at Sotheby's"}
 	for k, v := range parseRequestHeaders(headers) {
 		if v != "[FILTERED]" {
 			t.Errorf("expected '%s' to be [FILTERED], but was '%s'", k, v)

--- a/sessions/tracker.go
+++ b/sessions/tracker.go
@@ -130,7 +130,12 @@ func (s *sessionTracker) flushSessionsAndRepeatSignal(shutdown chan<- os.Signal,
 			s.config.logf("%v", err)
 		}
 	}
-	syscall.Kill(syscall.Getpid(), sig)
+
+	if p, err := os.FindProcess(os.Getpid()); err != nil {
+		s.config.logf("%v", err)
+	} else {
+		p.Signal(sig)
+	}
 }
 
 func (s *sessionTracker) FlushSessions() {


### PR DESCRIPTION
## Goal

Fix compilation error on Windows. Windows users can now compile projects with the 1.4.x releases of bugsnag-go.

## Discussion

This fix is a considerable net positive as it fixes the compilation error on Windows. However, the caveat to that is that interrupts are now swallowed (on Windows only) as programmatically sending interrupts on Windows is not implemented in the Go standard library. This means that users might have to interrupt their application twice in order to trigger an interrupt.

## Review

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language