### PR TITLE
Use runtime.CallersFrames to create StackFrames

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -105,13 +105,8 @@ func (err *Error) Stack() []byte {
 // stack.
 func (err *Error) StackFrames() []StackFrame {
 	if err.frames == nil {
-		err.frames = make([]StackFrame, len(err.stack))
-
-		for i, pc := range err.stack {
-			err.frames[i] = NewStackFrame(pc)
-		}
+		err.frames = runtimeToErrorFrames(pcsToFrames(err.stack))
 	}
-
 	return err.frames
 }
 

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -133,15 +133,6 @@ func ExampleNew_skip() {
 	}()
 }
 
-func ExampleError_Stack() {
-	e := New("Oh noes!", 1)
-	fmt.Printf("Error: %s\n", e.Error())
-	fmt.Printf("Stack is %d bytes", len(e.Stack()))
-	// Output:
-	// Error: Oh noes!
-	// Stack is 505 bytes
-}
-
 func a() error {
 	b(5)
 	return nil

--- a/errors/stackframe.go
+++ b/errors/stackframe.go
@@ -95,3 +95,31 @@ func packageAndName(fn *runtime.Func) (string, string) {
 	name = strings.Replace(name, "·", ".", -1)
 	return pkg, name
 }
+
+func pcsToFrames(pcs []uintptr) []runtime.Frame {
+	frames := runtime.CallersFrames(pcs)
+	s := make([]runtime.Frame, 0, len(pcs))
+	for {
+		frame, more := frames.Next()
+		s = append(s, frame)
+		if !more {
+			break
+		}
+	}
+	return s
+}
+
+func runtimeToErrorFrames(rtFrames []runtime.Frame) []StackFrame {
+	frames := make([]StackFrame, len(rtFrames))
+	for i, f := range rtFrames {
+		pkg, name := packageAndName(f.Func)
+		frames[i] = StackFrame{
+			File:           f.File,
+			LineNumber:     f.Line,
+			Name:           name,
+			Package:        pkg,
+			ProgramCounter: f.PC,
+		}
+	}
+	return frames
+}

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -117,7 +117,6 @@ func TestStackframesAreSkippedCorrectly(t *testing.T) {
 }
 
 func assertStackframeCount(t *testing.T, expCount int) {
-	t.Helper()
 	report, _ := simplejson.NewJson(<-bugsnaggedReports)
 	stacktrace := GetIndex(GetIndex(report, "events", 0), "exceptions", 0).Get("stacktrace")
 	if s := stacktrace.MustArray(); len(s) != expCount {


### PR DESCRIPTION
## Goal

Stack traces from `errors.Error` are incomplete and miss functions. In particular, inlined functions are missing.

Additionally, the tests for `errors` were failing.

Also fixes #44 

## Design

The change is to user `runtime.CallersFrames` to translate program counters to symbolic information as recommended by the golang docs.

## Changeset

### Added
`errors.NewStackFrameFromRuntime`

### Removed
None

### Changed
`errors.Error.StackFrame`

## Tests

Unit tests were fixed to fail for the right reasons (stack frame content, not formatting). All unit tests were run and passed.

### Outstanding Questions

`errors.StackFrame.Func()` still relies on `runtime.FuncForPC` which is less than ideal. Within the library, it is primarily used on constructor of `StackFrame`s. One way to give the right `Func` would be to save the `Func` on the `StackFrame` itself on construction from a `runtime.Frame`.

## Review
For the submitter, initial self-review:

- [X] Commented on code changes inline explain the reasoning behind the approach
- [X] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [X] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [X] Initial review of the intended approach, not yet feature complete
  - [X] Structural review of the classes, functions, and properties modified
  - [X] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
