### PR TITLE
Use CallersFrames to build StackFrames (required for go 1.12)

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -105,10 +105,14 @@ func (err *Error) Stack() []byte {
 // stack.
 func (err *Error) StackFrames() []StackFrame {
 	if err.frames == nil {
-		err.frames = make([]StackFrame, len(err.stack))
-
-		for i, pc := range err.stack {
-			err.frames[i] = NewStackFrame(pc)
+		err.frames = make([]StackFrame, 0, len(err.stack))
+		callers := runtime.CallersFrames(err.stack)
+		for {
+			frame, more := callers.Next()
+			err.frames = append(err.frames, NewStackFrame(frame))
+			if !more {
+				break
+			}
 		}
 	}
 

--- a/errors/stackframe.go
+++ b/errors/stackframe.go
@@ -16,30 +16,29 @@ type StackFrame struct {
 	Name           string
 	Package        string
 	ProgramCounter uintptr
+	rFunc          *runtime.Func
 }
 
-// NewStackFrame popoulates a stack frame object from the program counter.
-func NewStackFrame(pc uintptr) (frame StackFrame) {
+// NewStackFrame popoulates a stack frame object from runtime frame.
+func NewStackFrame(f runtime.Frame) (frame StackFrame) {
 
-	frame = StackFrame{ProgramCounter: pc}
+	frame = StackFrame{
+		ProgramCounter: f.PC,
+		rFunc:          f.Func,
+		File:           f.File,
+		LineNumber:     f.Line,
+	}
 	if frame.Func() == nil {
 		return
 	}
 	frame.Package, frame.Name = packageAndName(frame.Func())
-
-	// pc -1 because the program counters we use are usually return addresses,
-	// and we want to show the line that corresponds to the function call
-	frame.File, frame.LineNumber = frame.Func().FileLine(pc - 1)
 	return
 
 }
 
 // Func returns the function that this stackframe corresponds to
 func (frame *StackFrame) Func() *runtime.Func {
-	if frame.ProgramCounter == 0 {
-		return nil
-	}
-	return runtime.FuncForPC(frame.ProgramCounter)
+	return frame.rFunc
 }
 
 // String returns the stackframe formatted in the same way as go does

--- a/errors/stackframe_test.go
+++ b/errors/stackframe_test.go
@@ -1,0 +1,55 @@
+package errors
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func Test_StackFrames(t *testing.T) {
+	err := boom(5)
+	stack := getStack(err)
+	frames := getFrames(stack)
+	// for _, frame := range frames {
+	// 	fmt.Printf("%s:%d\n\t%s\n", frame.File, frame.Line, frame.Function)
+	// }
+
+	err2 := &Error{Err: err, stack: stack}
+	// fmt.Println(string(err2.Stack()))
+	frames2 := err2.StackFrames()
+	if name, name2 := frames[0].Function, frames2[0].Func().Name(); name != name2 {
+		t.Errorf("top frames don't match\n%s\n%s", name, name2)
+	}
+}
+
+func boom(depth int) error {
+	if depth > 0 {
+		return boom(depth - 1)
+	}
+	return errors.New("boom")
+}
+
+func getStack(err error) []uintptr {
+	type withStackTrace interface {
+		StackTrace() errors.StackTrace
+	}
+	frames := err.(withStackTrace).StackTrace()
+	stack := make([]uintptr, len(frames))
+	for i, f := range frames {
+		stack[i] = uintptr(f)
+	}
+	return stack
+}
+
+func getFrames(stack []uintptr) (frames []runtime.Frame) {
+	callers := runtime.CallersFrames(stack)
+	for {
+		frame, more := callers.Next()
+		frames = append(frames, frame)
+		if !more {
+			break
+		}
+	}
+	return frames
+}


### PR DESCRIPTION
## Goal

Go 1.12 uses more aggressive function call inlining which requires employing `runtime.CallersFrames()` to rebuild the function call stack correctly. (see https://golang.org/doc/go1.12#compiler). Included test case demonstrates the problem when trying to reconstruct the stack captured by the `github.com/pkg/errors` package.

If you run the test with the debug prints uncommented (and without the fix), you'll see that the top frame in the original stack and the top frame in the stack built by `StackFrames()` don't match. This is because the `errors.New()` call is (likely) inlined and therefore this part of https://golang.org/pkg/runtime/#FuncForPC applies

> If pc represents multiple functions because of inlining, it returns the a *Func describing the innermost function, but with an entry of the outermost function.

```
$ go test -run StackFrames
```
```
/Users/martin/go/src/github.com/mkobetic/bugsnag-go/errors/stackframe_test.go:31
	github.com/mkobetic/bugsnag-go/errors.boom
/Users/martin/go/src/github.com/mkobetic/bugsnag-go/errors/stackframe_test.go:29
	github.com/mkobetic/bugsnag-go/errors.boom
/Users/martin/go/src/github.com/mkobetic/bugsnag-go/errors/stackframe_test.go:29
	github.com/mkobetic/bugsnag-go/errors.boom
/Users/martin/go/src/github.com/mkobetic/bugsnag-go/errors/stackframe_test.go:29
	github.com/mkobetic/bugsnag-go/errors.boom
/Users/martin/go/src/github.com/mkobetic/bugsnag-go/errors/stackframe_test.go:29
	github.com/mkobetic/bugsnag-go/errors.boom
/Users/martin/go/src/github.com/mkobetic/bugsnag-go/errors/stackframe_test.go:29
	github.com/mkobetic/bugsnag-go/errors.boom
/Users/martin/go/src/github.com/mkobetic/bugsnag-go/errors/stackframe_test.go:12
	github.com/mkobetic/bugsnag-go/errors.Test_StackFrames
/usr/local/go/src/testing/testing.go:865
	testing.tRunner
/usr/local/go/src/runtime/asm_amd64.s:1337
	runtime.goexit
```
```
/Users/martin/shopify/go/src/github.com/pkg/errors/errors.go:105 (0x10f9ea0)
	New: stack: callers(),
/Users/martin/go/src/github.com/mkobetic/bugsnag-go/errors/stackframe_test.go:29 (0x10f9f36)
	boom: return boom(depth - 1)
/Users/martin/go/src/github.com/mkobetic/bugsnag-go/errors/stackframe_test.go:29 (0x10f9f36)
	boom: return boom(depth - 1)
/Users/martin/go/src/github.com/mkobetic/bugsnag-go/errors/stackframe_test.go:29 (0x10f9f36)
	boom: return boom(depth - 1)
/Users/martin/go/src/github.com/mkobetic/bugsnag-go/errors/stackframe_test.go:29 (0x10f9f36)
	boom: return boom(depth - 1)
/Users/martin/go/src/github.com/mkobetic/bugsnag-go/errors/stackframe_test.go:29 (0x10f9f36)
	boom: return boom(depth - 1)
/Users/martin/go/src/github.com/mkobetic/bugsnag-go/errors/stackframe_test.go:12 (0x10f994f)
	Test_StackFrames: err := boom(5)
/usr/local/go/src/testing/testing.go:865 (0x10b97f0)
	tRunner: fn(t)
/usr/local/go/src/runtime/asm_amd64.s:1337 (0x1057761)
	goexit: BYTE	$0x90	// NOP
```
```
--- FAIL: Test_StackFrames (0.00s)
    /Users/martin/go/src/github.com/mkobetic/bugsnag-go/errors/stackframe_test.go:22: top frames don't match
        github.com/mkobetic/bugsnag-go/errors.boom
        github.com/pkg/errors.New
FAIL
FAIL	github.com/mkobetic/bugsnag-go/errors	0.007s
Error: Tests failed.

```

## Design

Use the `runtime.CallersFrames()` function to reconstruct the stack as documented.

## Changeset

Since the use of `FuncForPC` should be avoided we need to create `StackFrames` from `runtime.Frames` instead of PCs. The change modifies `StackFrames()` and `NewStackFrame()` accordingly.

## Tests

Added `Test_StackFrames` to demonstrate the problem. I tried to reproduce it without using the `github.com/pkg/errors` at first but was struggling to get the compiler to inline. So I reverted back to using the errors package where I first observed the problem. We can try harder to reproduce without the package or otherwise include it in the dependencies (My test runs pulled the package from my GOPATH).

## Discussion

I made this PR largely to document the problem and propose the solution. Feel free to reject it for a different approach.

### Alternative Approaches

This is the documented way to reconstruct the call stack, it's probably not worth trying to come up with alternative solutions.

### Outstanding Questions

1. What do we want to do with `github.com/pkg/errors` in the test case. Can it be added as a dependency or should we try harder to reproduce inlining without it?

## Review

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
