### PR TITLE
Redact request url

### DIFF
--- a/bugsnag.go
+++ b/bugsnag.go
@@ -237,7 +237,7 @@ func init() {
 		AppVersion:          "",
 		AutoCaptureSessions: true,
 		ReleaseStage:        "",
-		ParamsFilters:       []string{"password", "secret", "authorization", "cookie"},
+		ParamsFilters:       []string{"password", "secret", "authorization", "cookie", "access_token"},
 		SourceRoot:          sourceRoot,
 		ProjectPackages:     []string{"main*"},
 		NotifyReleaseStages: nil,

--- a/request_extractor.go
+++ b/request_extractor.go
@@ -62,7 +62,7 @@ func sanitizeURL(req *http.Request) string {
 						continue
 					}
 
-					values[i] = "FILTERED"
+					values[i] = "BUGSNAG_URL_FILTERED"
 					changed = true
 				}
 			}
@@ -70,6 +70,7 @@ func sanitizeURL(req *http.Request) string {
 
 		if changed {
 			rawQuery = parsedQuery.Encode()
+			rawQuery = strings.Replace(rawQuery, "BUGSNAG_URL_FILTERED", "[FILTERED]", -1)
 		}
 	}
 

--- a/request_extractor.go
+++ b/request_extractor.go
@@ -60,12 +60,7 @@ func sanitizeURL(req *http.Request) string {
 	changed := false
 	for key, values := range parsedQuery {
 		if contains(Config.ParamsFilters, key) {
-			for i, v := range values {
-				if len(v) == 0 {
-					// No need to filter empty parameters.
-					continue
-				}
-
+			for i := range values {
 				values[i] = "BUGSNAG_URL_FILTERED"
 				changed = true
 			}

--- a/request_extractor.go
+++ b/request_extractor.go
@@ -52,26 +52,29 @@ func sanitizeURL(req *http.Request) string {
 
 	rawQuery := req.URL.RawQuery
 	parsedQuery, err := url.ParseQuery(req.URL.RawQuery)
-	if err == nil {
-		changed := false
-		for key, values := range parsedQuery {
-			if contains(Config.ParamsFilters, key) {
-				for i, v := range values {
-					if len(v) == 0 {
-						// No need to filter empty parameters.
-						continue
-					}
 
-					values[i] = "BUGSNAG_URL_FILTERED"
-					changed = true
+	if err != nil {
+		return scheme + "://" + req.Host + req.RequestURI
+	}
+
+	changed := false
+	for key, values := range parsedQuery {
+		if contains(Config.ParamsFilters, key) {
+			for i, v := range values {
+				if len(v) == 0 {
+					// No need to filter empty parameters.
+					continue
 				}
+
+				values[i] = "BUGSNAG_URL_FILTERED"
+				changed = true
 			}
 		}
+	}
 
-		if changed {
-			rawQuery = parsedQuery.Encode()
-			rawQuery = strings.Replace(rawQuery, "BUGSNAG_URL_FILTERED", "[FILTERED]", -1)
-		}
+	if changed {
+		rawQuery = parsedQuery.Encode()
+		rawQuery = strings.Replace(rawQuery, "BUGSNAG_URL_FILTERED", "[FILTERED]", -1)
 	}
 
 	u := url.URL{

--- a/request_extractor_test.go
+++ b/request_extractor_test.go
@@ -56,30 +56,34 @@ func TestRequestExtractorCanHandleAbsentContext(t *testing.T) {
 }
 
 func TestExtractRequestInfoFromReq_RedactURL(t *testing.T) {
-	testCases := []struct { originalURI, expectedURL string}{
-		{"", "http://example.com"},
-		{"/", "http://example.com/"},
-		{"/foo.html", "http://example.com/foo.html"},
-		{"/foo.html?q=something&bar=123", "http://example.com/foo.html?bar=123&q=something"},
-		{"/foo.html?foo=1&foo=2&foo=3", "http://example.com/foo.html?foo=1&foo=2&foo=3"},
+	testCases := []struct{ in, exp string }{
+		{in: "", exp: "http://example.com"},
+		{in: "/", exp: "http://example.com/"},
+		{in: "/foo.html", exp: "http://example.com/foo.html"},
+		{in: "/foo.html?q=something&bar=123", exp: "http://example.com/foo.html?q=something&bar=123"},
+		{in: "/foo.html?foo=1&foo=2&foo=3", exp: "http://example.com/foo.html?foo=1&foo=2&foo=3"},
 
-		{"/foo.html?access_token=something", "http://example.com/foo.html?access_token=FILTERED"},
-		{"/foo.html?access_token=something&access_token=", "http://example.com/foo.html?access_token=FILTERED&access_token="},
+		// Invalid query string.
+		{in: "/foo?%", exp: "http://example.com/foo?%"},
+
+		// Query params contain secrets
+		{in: "/foo.html?access_token=something", exp: "http://example.com/foo.html?access_token=FILTERED"},
+		{in: "/foo.html?access_token=something&access_token=", exp: "http://example.com/foo.html?access_token=FILTERED&access_token="},
 	}
 
 	for _, tc := range testCases {
-		parsedURL, err := url.Parse(tc.originalURI)
+		parsedURL, err := url.Parse(tc.in)
 		if err != nil {
-			t.Fatalf("error parsing originalURI: %v", err)
+			t.Fatalf("error parsing originalURI (bad test): %v", err)
 		}
 
 		req := &http.Request{
 			Host: "example.com",
-			URL: parsedURL,
+			URL:  parsedURL,
 		}
 		result := extractRequestInfoFromReq(req)
-		if result.URL != tc.expectedURL {
-			t.Errorf("expected URL to be '%s' but was '%s'", tc.expectedURL, result.URL)
+		if result.URL != tc.exp {
+			t.Errorf("expected URL to be '%s' but was '%s'", tc.exp, result.URL)
 		}
 	}
 }

--- a/request_extractor_test.go
+++ b/request_extractor_test.go
@@ -75,9 +75,14 @@ func TestExtractRequestInfoFromReq_RedactURL(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		requestURI := tc.in.Path
+		if tc.in.RawQuery != "" {
+			requestURI += "?" + tc.in.RawQuery
+		}
 		req := &http.Request{
-			Host: "example.com",
-			URL:  &tc.in,
+			Host:       "example.com",
+			URL:        &tc.in,
+			RequestURI: requestURI,
 		}
 		result := extractRequestInfoFromReq(req)
 		if result.URL != tc.exp {

--- a/request_extractor_test.go
+++ b/request_extractor_test.go
@@ -71,7 +71,7 @@ func TestExtractRequestInfoFromReq_RedactURL(t *testing.T) {
 
 		// Query params contain secrets
 		{in: url.URL{Path: "/foo.html", RawQuery: "access_token=something"}, exp: "http://example.com/foo.html?access_token=[FILTERED]"},
-		{in: url.URL{Path: "/foo.html", RawQuery: "access_token=something&access_token=&foo=bar"}, exp: "http://example.com/foo.html?access_token=[FILTERED]&access_token=&foo=bar"},
+		{in: url.URL{Path: "/foo.html", RawQuery: "access_token=something&access_token=&foo=bar"}, exp: "http://example.com/foo.html?access_token=[FILTERED]&access_token=[FILTERED]&foo=bar"},
 	}
 
 	for _, tc := range testCases {

--- a/request_extractor_test.go
+++ b/request_extractor_test.go
@@ -56,30 +56,28 @@ func TestRequestExtractorCanHandleAbsentContext(t *testing.T) {
 }
 
 func TestExtractRequestInfoFromReq_RedactURL(t *testing.T) {
-	testCases := []struct{ in, exp string }{
-		{in: "", exp: "http://example.com"},
-		{in: "/", exp: "http://example.com/"},
-		{in: "/foo.html", exp: "http://example.com/foo.html"},
-		{in: "/foo.html?q=something&bar=123", exp: "http://example.com/foo.html?q=something&bar=123"},
-		{in: "/foo.html?foo=1&foo=2&foo=3", exp: "http://example.com/foo.html?foo=1&foo=2&foo=3"},
+	testCases := []struct {
+		in  url.URL
+		exp string
+	}{
+		{in: url.URL{}, exp: "http://example.com"},
+		{in: url.URL{Path: "/"}, exp: "http://example.com/"},
+		{in: url.URL{Path: "/foo.html"}, exp: "http://example.com/foo.html"},
+		{in: url.URL{Path: "/foo.html", RawQuery: "q=something&bar=123"}, exp: "http://example.com/foo.html?q=something&bar=123"},
+		{in: url.URL{Path: "/foo.html", RawQuery: "foo=1&foo=2&foo=3"}, exp: "http://example.com/foo.html?foo=1&foo=2&foo=3"},
 
 		// Invalid query string.
-		{in: "/foo?%", exp: "http://example.com/foo?%"},
+		{in: url.URL{Path: "/foo", RawQuery: "%"}, exp: "http://example.com/foo?%"},
 
 		// Query params contain secrets
-		{in: "/foo.html?access_token=something", exp: "http://example.com/foo.html?access_token=FILTERED"},
-		{in: "/foo.html?access_token=something&access_token=", exp: "http://example.com/foo.html?access_token=FILTERED&access_token="},
+		{in: url.URL{Path: "/foo.html", RawQuery: "access_token=something"}, exp: "http://example.com/foo.html?access_token=[FILTERED]"},
+		{in: url.URL{Path: "/foo.html", RawQuery: "access_token=something&access_token=&foo=bar"}, exp: "http://example.com/foo.html?access_token=[FILTERED]&access_token=&foo=bar"},
 	}
 
 	for _, tc := range testCases {
-		parsedURL, err := url.Parse(tc.in)
-		if err != nil {
-			t.Fatalf("error parsing originalURI (bad test): %v", err)
-		}
-
 		req := &http.Request{
 			Host: "example.com",
-			URL:  parsedURL,
+			URL:  &tc.in,
 		}
 		result := extractRequestInfoFromReq(req)
 		if result.URL != tc.exp {


### PR DESCRIPTION
## Goal

Currently, when the Bugsnag client extracts the URL from the request, it includes the full query parameters, without any filtering/redaction. This will leak any sensitive keys sent as query parameters, like access tokens.

This PR changes that so that we go through each query parameter and filter out sensitive ones (similar to how we do for request headers).

This PR also adds `access_token` as a default sensitive parameter, since it's very unlikely users want to include those in Bugsnag reports.

<!-- What is the intent of this change?
e.g. "When initializing the Bugsnag client, it is currently difficult to (...)
      this change simplifies the process by (...)"

     "Improves the performance of data filtering"

     "Adds additional test coverage to multi-threaded use of Configuration
      objects"
-->


## Changeset

<!-- 
### Added

### Removed
-->

### Changed

`extractRequestInfoFromReq`

## Tests

<!-- How was this change tested? What manual and automated tests were
     run/added? -->

I've added tests for the function.

## Discussion

### Alternative Approaches

<!-- What other approaches were considered or discussed? -->

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

One drawback of this change is that the URL query parameters sent to Bugsnag will no longer be in the order that the client sent them, but sorted alphabetically by key. This is because `url.ParseQuery` returns a (type-aliased) `map[string][]string`, and the corresponding `Encode` sorts on key.

We could attempt a custom implementation of the `Encode` function to sort according to the original order, but I'm not sure it's worth it.

### Linked issues

<!--

Fixes #
Related to #

-->

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [x] Consistency across platforms for structures or concepts added or modified
- [x] Consistency between the changeset and the goal stated above
- [x] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [x] Usage friction - is the proposed change in usage cumbersome or complicated?
- [x] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [x] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [x] Thoroughness of added tests and any missing edge cases
- [x] Idiomatic use of the language
