### PR TITLE
[chore] Drop Go 1.7 x Gin (latest) unit test combo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
 jobs:
   include:
     - stage: gotest
+      env: GO_VERSION=1.7
       script: make ci
       go: "1.7"
     - script: make ci

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,14 @@ updatedeps:
 	go get -v -d -u ./...
 
 test: alldeps
-	#TODO: 2018-09-20 Not testing the 'errors' package as it relies on some very runtime-specific implementation details.
-	# The testing of 'errors' needs to be revisited
-	go test . ./gin ./martini ./negroni ./sessions ./headers
+	@#TODO: 2018-09-20 Not testing the 'errors' package as it relies on some very runtime-specific implementation details.
+	@# The testing of 'errors' needs to be revisited
+	@# Additionally skipping Gin if the Go version is 1.7, as the latest version of Gin has dropped support.
+	@if [ "$(GO_VERSION)" = "1.7" ]; then \
+		go test . ./martini ./negroni ./sessions ./headers; \
+	else \
+		go test . ./gin ./martini ./negroni ./sessions ./headers; \
+	fi
 	@go vet 2>/dev/null ; if [ $$? -eq 3 ]; then \
 		go get golang.org/x/tools/cmd/vet; \
 	fi


### PR DESCRIPTION
We currently pull down the latest versions of all our dependencies, including Gin, before attempting to run our tests. Gin has recently dropped their support for Go 1.7, and we therefore have to ignore the Gin tests when running CI against Go 1.7.

Additionally silence comments in Makefile

### Linked issues

Related to #117 as this PR is blocked by a failing build which this aims to solve.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
