### PR TITLE
v1.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
 jobs:
   include:
     - stage: gotest
+      env: GO_VERSION=1.7
       script: make ci
       go: "1.7"
     - script: make ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.5.2 (2019-05-20)
+
+This release adds `"access_token"` to the default list of keys to filter and introduces filtering of URL query parameters under the request tab.
+
+### Enhancements
+
+* Adds filtering of URL parameters in the request tab of an event. Additionally adds `access_token` to the `ParamsFilters` by default.
+  [#117](https://github.com/bugsnag/bugsnag-go/pull/117)
+  [Adam Renberg Tamm](https://github.com/tgwizard)
+* Ignore Gin unit tests when running against the latest version of Gin on Go 1.7 as Gin has dropped support for Go 1.6 and Go 1.7.
+  [#118](https://github.com/bugsnag/bugsnag-go/pull/118)
+
 ## 1.5.1 (2019-04-15)
 
 This release re-introduces prioritizing user specified error classes over the inferred error class.

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,14 @@ updatedeps:
 	go get -v -d -u ./...
 
 test: alldeps
-	#TODO: 2018-09-20 Not testing the 'errors' package as it relies on some very runtime-specific implementation details.
-	# The testing of 'errors' needs to be revisited
-	go test . ./gin ./martini ./negroni ./sessions ./headers
+	@#TODO: 2018-09-20 Not testing the 'errors' package as it relies on some very runtime-specific implementation details.
+	@# The testing of 'errors' needs to be revisited
+	@# Additionally skipping Gin if the Go version is 1.7, as the latest version of Gin has dropped support.
+	@if [ "$(GO_VERSION)" = "1.7" ]; then \
+		go test . ./martini ./negroni ./sessions ./headers; \
+	else \
+		go test . ./gin ./martini ./negroni ./sessions ./headers; \
+	fi
 	@go vet 2>/dev/null ; if [ $$? -eq 3 ]; then \
 		go get golang.org/x/tools/cmd/vet; \
 	fi

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -237,7 +237,7 @@ func init() {
 		AppVersion:          "",
 		AutoCaptureSessions: true,
 		ReleaseStage:        "",
-		ParamsFilters:       []string{"password", "secret", "authorization", "cookie"},
+		ParamsFilters:       []string{"password", "secret", "authorization", "cookie", "access_token"},
 		SourceRoot:          sourceRoot,
 		ProjectPackages:     []string{"main*"},
 		NotifyReleaseStages: nil,

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -21,7 +21,7 @@ import (
 )
 
 // VERSION defines the version of this Bugsnag notifier
-const VERSION = "1.5.1"
+const VERSION = "1.5.2"
 
 var panicHandlerOnce sync.Once
 var sessionTrackerOnce sync.Once

--- a/payload_test.go
+++ b/payload_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/bugsnag/bugsnag-go/sessions"
 )
 
-const expSmall = `{"apiKey":"","events":[{"app":{"releaseStage":""},"device":{},"exceptions":[{"errorClass":"","message":"","stacktrace":null}],"metaData":{},"payloadVersion":"4","severity":"","unhandled":false}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.5.1"}}`
+const expSmall = `{"apiKey":"","events":[{"app":{"releaseStage":""},"device":{},"exceptions":[{"errorClass":"","message":"","stacktrace":null}],"metaData":{},"payloadVersion":"4","severity":"","unhandled":false}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.5.2"}}`
 
 // The large payload has a timestamp in it which makes it awkward to assert against.
 // Instead, assert that the timestamp property exist, along with the rest of the expected payload
 const expLargePre = `{"apiKey":"166f5ad3590596f9aa8d601ea89af845","events":[{"app":{"releaseStage":"mega-production","type":"gin","version":"1.5.2"},"context":"/api/v2/albums","device":{"hostname":"super.duper.site"},"exceptions":[{"errorClass":"error class","message":"error message goes here","stacktrace":[{"method":"doA","file":"a.go","lineNumber":65},{"method":"fetchB","file":"b.go","lineNumber":99,"inProject":true},{"method":"incrementI","file":"i.go","lineNumber":651}]}],"groupingHash":"custom grouping hash","metaData":{"custom tab":{"my key":"my value"}},"payloadVersion":"4","session":{"startedAt":"`
-const expLargePost = `,"severity":"info","severityReason":{"type":"unhandledError"},"unhandled":true,"user":{"id":"1234baerg134","name":"Kool Kidz on da bus","email":"typo@busgang.com"}}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.5.1"}}`
+const expLargePost = `,"severity":"info","severityReason":{"type":"unhandledError"},"unhandled":true,"user":{"id":"1234baerg134","name":"Kool Kidz on da bus","email":"typo@busgang.com"}}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.5.2"}}`
 
 func TestMarshalEmptyPayload(t *testing.T) {
 	sessionTracker = sessions.NewSessionTracker(&sessionTrackingConfig)


### PR DESCRIPTION
This release adds `"access_token"` to the default list of keys to filter and introduces filtering of URL query parameters under the request tab.

Also ensures that our CI is running well by ignoring Go 1.7 unit tests against the latest version of Gin.

## Goal

Ensure we completely filter URL parameters by excluding them from the URL string we add to the Request tab.

## Tests

Unit tested and manually verified. Maze tests deemed overkill.

## Review

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
