### PR TITLE
Don't run builds against Gin + Go 1.8/1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ jobs:
       script: make ci
       go: "1.7"
     - script: make ci
+      env: GO_VERSION=1.8
       go: "1.8"
     - script: make ci
+      env: GO_VERSION=1.9
       go: "1.9"
     - script: make ci
       go: "1.10"

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ updatedeps:
 test: alldeps
 	@#TODO: 2018-09-20 Not testing the 'errors' package as it relies on some very runtime-specific implementation details.
 	@# The testing of 'errors' needs to be revisited
-	@# Additionally skipping Gin if the Go version is 1.7, as the latest version of Gin has dropped support.
-	@if [ "$(GO_VERSION)" = "1.7" ]; then \
+	@# Additionally skipping Gin if the Go version is lower than 1.9, as the latest version of Gin has dropped support for these versions.
+	@if [ "$(GO_VERSION)" = "1.7" ] || [ "$(GO_VERSION)" = "1.8" ] || [ "$(GO_VERSION)" = "1.9" ]; then \
 		go test . ./martini ./negroni ./sessions ./headers; \
 	else \
 		go test . ./gin ./martini ./negroni ./sessions ./headers; \


### PR DESCRIPTION
Gin has dropped support for these versions in its latest release, [blocking the runtime versions work](https://travis-ci.com/bugsnag/bugsnag-go/builds/117849485).

This is an extension of #118