### PR TITLE
ci: Add Go v1.13 to CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,13 @@ jobs:
       go: "1.11"
     - script: make ci
       go: "1.12"
+    - script: make ci
+      go: "1.13"
 
     - stage: plain go app tests
+      script: make testplain
+      env: GO_VERSION=1.13
+    - if: branch = master
       script: make testplain
       env: GO_VERSION=1.12
     - if: branch = master
@@ -49,6 +54,9 @@ jobs:
 
 
     - stage: net/http tests
+      script: make testnethttp
+      env: GO_VERSION=1.13
+    - if: branch = master
       script: make testnethttp
       env: GO_VERSION=1.12
     - if: branch = master
@@ -71,6 +79,11 @@ jobs:
     - stage: gin tests
       script: make testgin
       env:
+        - GO_VERSION=1.13
+        - GIN_VERSION=v1.3.0
+    - if: branch = master
+      script: make testgin
+      env:
         - GO_VERSION=1.12
         - GIN_VERSION=v1.3.0
     - if: branch = master
@@ -102,6 +115,11 @@ jobs:
     - if: branch = master
       script: make testgin
       env:
+        - GO_VERSION=1.13
+        - GIN_VERSION=v1.2
+    - if: branch = master
+      script: make testgin
+      env:
         - GO_VERSION=1.12
         - GIN_VERSION=v1.2
     - if: branch = master
@@ -133,6 +151,11 @@ jobs:
     - if: branch = master
       script: make testgin
       env:
+        - GO_VERSION=1.13
+        - GIN_VERSION=v1.1
+    - if: branch = master
+      script: make testgin
+      env:
         - GO_VERSION=1.12
         - GIN_VERSION=v1.1
     - if: branch = master
@@ -161,6 +184,11 @@ jobs:
         - GO_VERSION=1.7
         - GIN_VERSION=v1.1
 
+    - if: branch = master
+      script: make testgin
+      env:
+        - GO_VERSION=1.13
+        - GIN_VERSION=v1.0
     - if: branch = master
       script: make testgin
       env:
@@ -194,6 +222,9 @@ jobs:
 
     - stage: martini tests
       script: make testmartini
+      env: GO_VERSION=1.13
+    - if: branch = master
+      script: make testmartini
       env: GO_VERSION=1.12
     - if: branch = master
       script: make testmartini
@@ -214,6 +245,11 @@ jobs:
     - stage: negroni tests
       script: make testnegroni
       env:
+        - GO_VERSION=1.13
+        - NEGRONI_VERSION=v1.0.0
+    - if: branch = master
+      script: make testnegroni
+      env:
         - GO_VERSION=1.12
         - NEGRONI_VERSION=v1.0.0
     - if: branch = master
@@ -245,6 +281,11 @@ jobs:
     - if: branch = master
       script: make testnegroni
       env:
+        - GO_VERSION=1.13
+        - NEGRONI_VERSION=v0.3.0
+    - if: branch = master
+      script: make testnegroni
+      env:
         - GO_VERSION=1.12
         - NEGRONI_VERSION=v0.3.0
     - if: branch = master
@@ -273,6 +314,11 @@ jobs:
         - GO_VERSION=1.7
         - NEGRONI_VERSION=v0.3.0
 
+    - if: branch = master
+      script: make testnegroni
+      env:
+        - GO_VERSION=1.13
+        - NEGRONI_VERSION=v0.2.0
     - if: branch = master
       script: make testnegroni
       env:
@@ -308,6 +354,12 @@ jobs:
     - stage: revel tests
       script: make testrevel
       env:
+        - GO_VERSION=1.13
+        - REVEL_VERSION=v0.21.0
+        - REVEL_CMD_VERSION=v0.21.1
+    - if: branch = master
+      script: make testrevel
+      env:
         - GO_VERSION=1.12
         - REVEL_VERSION=v0.21.0
         - REVEL_CMD_VERSION=v0.21.1
@@ -339,6 +391,12 @@ jobs:
     - if: branch = master
       script: make testrevel
       env:
+        - GO_VERSION=1.13
+        - REVEL_VERSION=v0.20.0
+        - REVEL_CMD_VERSION=v0.20.2
+    - if: branch = master
+      script: make testrevel
+      env:
         - GO_VERSION=1.12
         - REVEL_VERSION=v0.20.0
         - REVEL_CMD_VERSION=v0.20.2
@@ -370,6 +428,12 @@ jobs:
     - if: branch = master
       script: make testrevel
       env:
+        - GO_VERSION=1.13
+        - REVEL_VERSION=v0.19.1
+        - REVEL_CMD_VERSION=v0.19.0
+    - if: branch = master
+      script: make testrevel
+      env:
         - GO_VERSION=1.12
         - REVEL_VERSION=v0.19.1
         - REVEL_CMD_VERSION=v0.19.0
@@ -392,6 +456,12 @@ jobs:
         - REVEL_VERSION=v0.19.1
         - REVEL_CMD_VERSION=v0.19.0
 
+    - if: branch = master
+      script: make testrevel
+      env:
+        - GO_VERSION=1.13
+        - REVEL_VERSION=v0.18.0
+        - REVEL_CMD_VERSION=v0.18.0
     - if: branch = master
       script: make testrevel
       env:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ deps:
 
 alldeps:
 	@if [ "$(GO_VERSION)" = "1.7" ] || [ "$(GO_VERSION)" = "1.8" ] || [ "$(GO_VERSION)" = "1.9" ]; then \
-		go get -v -d -t . ./martini ./negroni ./sessions ./headers; \
+		go get -v -d -t . ./martini ./negroni ./sessions ./headers ./device; \
 	else \
 		go get -v -d -t ./...; \
 	fi
@@ -20,9 +20,9 @@ test: alldeps
 	@# The testing of 'errors' needs to be revisited
 	@# Additionally skipping Gin if the Go version is lower than 1.9, as the latest version of Gin has dropped support for these versions.
 	@if [ "$(GO_VERSION)" = "1.7" ] || [ "$(GO_VERSION)" = "1.8" ] || [ "$(GO_VERSION)" = "1.9" ]; then \
-		go test . ./martini ./negroni ./sessions ./headers; \
+		go test . ./martini ./negroni ./sessions ./headers ./device; \
 	else \
-		go test . ./gin ./martini ./negroni ./sessions ./headers; \
+		go test . ./gin ./martini ./negroni ./sessions ./headers ./device; \
 	fi
 	@go vet 2>/dev/null ; if [ $$? -eq 3 ]; then \
 		go get golang.org/x/tools/cmd/vet; \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ deps:
 	go get -v -d ./...
 
 alldeps:
-	go get -v -d -t ./...
+	@if [ "$(GO_VERSION)" = "1.7" ] || [ "$(GO_VERSION)" = "1.8" ] || [ "$(GO_VERSION)" = "1.9" ]; then \
+		go get -v -d -t . ./martini ./negroni ./sessions ./headers; \
+	else \
+		go get -v -d -t ./...; \
+	fi
 
 updatedeps:
 	go get -v -d -u ./...


### PR DESCRIPTION
Adds Go v1.13 to the test matrix. This is now the default runtime version for CI.

Additionally:
- Gin acquired a transitive dependency on `math/bits` which is not available in Go ≤v1.9, so the `alldeps` make target has been updated to skip installing gin (and its dependencies) when testing against those versions of Go. The Gin tests were already skipped.
- Add missing `device` tests go `gotests` CI