### PR TITLE
Add support for Webassembly

### DIFF
--- a/panicwrap.go
+++ b/panicwrap.go
@@ -1,3 +1,5 @@
+// +build !js !wasm
+
 package bugsnag
 
 import (

--- a/panicwrap_test.go
+++ b/panicwrap_test.go
@@ -1,3 +1,5 @@
+// +build !js !wasm
+
 package bugsnag
 
 import (

--- a/panicwrap_wasm.go
+++ b/panicwrap_wasm.go
@@ -1,0 +1,5 @@
+// +build js,wasm
+
+package bugsnag
+
+func defaultPanicHandler() {}

--- a/sessions/process.go
+++ b/sessions/process.go
@@ -1,0 +1,17 @@
+// +build !js !wasm
+
+package sessions
+
+import (
+	"os"
+
+	"github.com/bugsnag/panicwrap"
+)
+
+// Checks to see if this is the application process, as opposed to the process
+// that monitors for panics
+func isApplicationProcess() bool {
+	// Application process is run first, and this will only have been set when
+	// the monitoring process runs
+	return "" == os.Getenv(panicwrap.DEFAULT_COOKIE_KEY)
+}

--- a/sessions/process_wasm.go
+++ b/sessions/process_wasm.go
@@ -1,0 +1,7 @@
+// +build js,wasm
+
+package sessions
+
+func isApplicationProcess() bool {
+	return false
+}

--- a/sessions/startup.go
+++ b/sessions/startup.go
@@ -3,9 +3,6 @@ package sessions
 import (
 	"context"
 	"net/http"
-	"os"
-
-	"github.com/bugsnag/panicwrap"
 )
 
 // SendStartupSession is called by Bugsnag on startup, which will send a
@@ -24,12 +21,4 @@ func SendStartupSession(config *SessionTrackingConfiguration) context.Context {
 	}
 	go publisher.publish([]*Session{session})
 	return context.WithValue(ctx, contextSessionKey, session)
-}
-
-// Checks to see if this is the application process, as opposed to the process
-// that monitors for panics
-func isApplicationProcess() bool {
-	// Application process is run first, and this will only have been set when
-	// the monitoring process runs
-	return "" == os.Getenv(panicwrap.DEFAULT_COOKIE_KEY)
 }


### PR DESCRIPTION
## Goal

Add support for WebAssembly.

## Design

Sets a no-op default panic handler when building for web assembly.

This nopes out of `panicwrap`, which relies on functions not available to wasm - and probably doesn't make much sense in a wasm world anyways.

## Changeset

### Changed
- Set default panic handler implementation based on build tags
