### PR TITLE
fix: use runtime.callersframes to handle inlined frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Account for inlined frames when unwinding stack traces by using
+  `runtime.CallersFrames`.
+  [#114](https://github.com/bugsnag/bugsnag-go/pull/114)
+  [#140](https://github.com/bugsnag/bugsnag-go/pull/140)
+
 ## 1.5.3 (2019-07-11)
 
 This release adds runtime version data to the report and session payloads, which will show up under the Device tab in the Bugsnag dashboard.

--- a/errors/stackframe.go
+++ b/errors/stackframe.go
@@ -16,6 +16,7 @@ type StackFrame struct {
 	Name           string
 	Package        string
 	ProgramCounter uintptr
+	function       *runtime.Func
 }
 
 // NewStackFrame popoulates a stack frame object from the program counter.
@@ -36,10 +37,7 @@ func NewStackFrame(pc uintptr) (frame StackFrame) {
 
 // Func returns the function that this stackframe corresponds to
 func (frame *StackFrame) Func() *runtime.Func {
-	if frame.ProgramCounter == 0 {
-		return nil
-	}
-	return runtime.FuncForPC(frame.ProgramCounter)
+	return frame.function
 }
 
 // String returns the stackframe formatted in the same way as go does


### PR DESCRIPTION
## Goal

Use [`runtime.CallersFrames`](https://golang.org/pkg/runtime/#CallersFrames) to unwind stack traces, taking into account any inlined frames (thus producing a more accurate trace).

Closes #114 

## Design

This is a trimmed down version of #114, avoiding changing public function signatures (for now) and avoiding pulling in `pkg/errors` (which will added to support the `pkg/errors` stacktrace format in a subsequent PR).

## Changeset

* Add a (private) `function` field to `StackFrame`. This caches the [`Func`](https://golang.org/pkg/runtime/#Func) value rather than using [`FuncForPC`](https://golang.org/pkg/runtime/#Func).
* Construct the stack by iterating over the frames returned by `runtime.CallersFrames` using the error `stack` value as input.

## Testing

* Updated the error tests to assert expected stack trace frames (ignoring system frames, which change between versions)
* Tested manually to confirm frames are processed correctly. Example trace from the `http` example project:

Before:
```
    runtime/iface.go:261 panicdottypeE
    main.go:39 unhandledCrash.func1
    main.go:39 unhandledCrash.func1
    net/http/server.go:2042 HandlerFunc.ServeHTTP
    ...
```

After:
```
    runtime/iface.go:261 panicdottypeE
    main.go:39 unhandledCrash
    net/http/server.go:2042 HandlerFunc.ServeHTTP
    ...
```