### PR TITLE
fix: send framework name with severity reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Send web framework name with severity reason if set. Previously this value was
+  ignored, obscuring the severity reason for failed web requests captured by
+  bugsnag middleware.
+
 ## 1.5.4 (2020-10-28)
 
 ### Bug fixes

--- a/features/gin_features/autonotify.feature
+++ b/features/gin_features/autonotify.feature
@@ -14,6 +14,8 @@ Scenario: An error report is sent when an AutoNotified crash occurs which later 
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is true
+  And the event "severityReason.type" equals "unhandledErrorMiddleware" for request 0
+  And the event "severityReason.attributes.framework" equals "Gin" for request 0
   And the exception "errorClass" equals "*runtime.TypeAssertionError"
   And the exception "message" matches "interface conversion: interface ({} )?is struct {}, not string"
 
@@ -26,5 +28,6 @@ Scenario: An error report is sent when a go routine crashes which is reported th
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is true
+  And the event "severityReason.type" equals "handledPanic" for request 0
   And the exception "errorClass" equals "*errors.errorString"
   And the exception "message" equals "Go routine killed with auto notify"

--- a/features/martini_features/autonotify.feature
+++ b/features/martini_features/autonotify.feature
@@ -14,6 +14,8 @@ Scenario: An error report is sent when an AutoNotified crash occurs which later 
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is true
+  And the event "severityReason.type" equals "unhandledErrorMiddleware" for request 0
+  And the event "severityReason.attributes.framework" equals "Martini" for request 0
   And the exception "errorClass" equals "*runtime.TypeAssertionError"
   And the exception "message" matches "interface conversion: interface ({} )?is struct {}, not string"
 
@@ -25,5 +27,6 @@ Scenario: An error report is sent when a go routine crashes which is reported th
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is true
+  And the event "severityReason.type" equals "handledPanic" for request 0
   And the exception "errorClass" equals "*errors.errorString"
   And the exception "message" equals "Go routine killed with auto notify"

--- a/features/negroni_features/autonotify.feature
+++ b/features/negroni_features/autonotify.feature
@@ -14,6 +14,8 @@ Scenario: An error report is sent when an AutoNotified crash occurs which later 
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is true
+  And the event "severityReason.type" equals "unhandledErrorMiddleware" for request 0
+  And the event "severityReason.attributes.framework" equals "Negroni" for request 0
   And the exception "errorClass" equals "*runtime.TypeAssertionError"
   And the exception "message" matches "interface conversion: interface ({} )?is struct {}, not string"
 
@@ -26,5 +28,6 @@ Scenario: An error report is sent when a go routine crashes which is reported th
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is true
+  And the event "severityReason.type" equals "handledPanic" for request 0
   And the exception "errorClass" equals "*errors.errorString"
   And the exception "message" equals "Go routine killed with auto notify"

--- a/features/revel_features/autonotify.feature
+++ b/features/revel_features/autonotify.feature
@@ -14,6 +14,8 @@ Scenario: An error report is sent when an AutoNotified crash occurs which later 
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is true
+  And the event "severityReason.type" equals "unhandledErrorMiddleware" for request 0
+  And the event "severityReason.attributes.framework" equals "Revel" for request 0
   And the exception "errorClass" equals "*runtime.TypeAssertionError"
   And the exception "message" matches "interface conversion: interface ({} )?is struct {}, not string"
 
@@ -26,5 +28,6 @@ Scenario: An error report is sent when a go routine crashes which is reported th
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is true
+  And the event "severityReason.type" equals "handledPanic" for request 0
   And the exception "errorClass" equals "*errors.errorString"
   And the exception "message" equals "Go routine killed with auto notify"

--- a/payload.go
+++ b/payload.go
@@ -128,7 +128,12 @@ func (p *payload) makeSession() *sessionJSON {
 
 func (p *payload) severityReasonPayload() *severityReasonJSON {
 	if reason := p.handledState.SeverityReason; reason != "" {
-		return &severityReasonJSON{Type: reason}
+		json := &severityReasonJSON{Type: reason}
+		if p.handledState.Framework != "" {
+			json.Attributes = make(map[string]string, 1)
+			json.Attributes["framework"] = p.handledState.Framework
+		}
+		return json
 	}
 	return nil
 }

--- a/payload_test.go
+++ b/payload_test.go
@@ -16,7 +16,7 @@ const expSmall = `{"apiKey":"","events":[{"app":{"releaseStage":""},"device":{"o
 // The large payload has a timestamp in it which makes it awkward to assert against.
 // Instead, assert that the timestamp property exist, along with the rest of the expected payload
 const expLargePre = `{"apiKey":"166f5ad3590596f9aa8d601ea89af845","events":[{"app":{"releaseStage":"mega-production","type":"gin","version":"1.5.3"},"context":"/api/v2/albums","device":{"hostname":"super.duper.site","osName":"%s","runtimeVersions":{"go":"%s"}},"exceptions":[{"errorClass":"error class","message":"error message goes here","stacktrace":[{"method":"doA","file":"a.go","lineNumber":65},{"method":"fetchB","file":"b.go","lineNumber":99,"inProject":true},{"method":"incrementI","file":"i.go","lineNumber":651}]}],"groupingHash":"custom grouping hash","metaData":{"custom tab":{"my key":"my value"}},"payloadVersion":"4","session":{"startedAt":"`
-const expLargePost = `,"severity":"info","severityReason":{"type":"unhandledError"},"unhandled":true,"user":{"id":"1234baerg134","name":"Kool Kidz on da bus","email":"typo@busgang.com"}}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.5.4"}}`
+const expLargePost = `,"severity":"info","severityReason":{"type":"unhandledError","attributes":{"framework":"gin"}},"unhandled":true,"user":{"id":"1234baerg134","name":"Kool Kidz on da bus","email":"typo@busgang.com"}}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.5.4"}}`
 
 func TestMarshalEmptyPayload(t *testing.T) {
 	sessionTracker = sessions.NewSessionTracker(&sessionTrackingConfig)

--- a/report.go
+++ b/report.go
@@ -53,7 +53,8 @@ type exceptionJSON struct {
 }
 
 type severityReasonJSON struct {
-	Type SeverityReason `json:"type,omitempty"`
+	Type                SeverityReason    `json:"type,omitempty"`
+	Attributes          map[string]string `json:"attributes,omitempty"`
 }
 
 type deviceJSON struct {


### PR DESCRIPTION
Framework was missing from handled state payload contents. Updated the JSON serializer to include it and the tests to validate the change. Handled events already included assertions to ensure the handled state was sent correctly.

## Testing

* Added new assertions for setting the framework value to the payload and web framework tests.
* Tested manually to ensure a custom handled state with a framework value was reflected correctly on the dashboard