### PR TITLE
feat(errors): extract pkg/errors stacktraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## TBD
 
+### Enhancements
+
+* Extract stacktrace contents on errors wrapped by
+  [`pkg/errors`](https://github.com/pkg/errors).
+
 ### Bug fixes
 
 * Send web framework name with severity reason if set. Previously this value was


### PR DESCRIPTION
## Goal

Support reporting stack traces captured using the [`pkg/errors`](https://github.com/pkg/errors) package instead of generating a new stack when `Notify()` is called.

Closes #128 - updates the premise to use the latest pre-release  branch and avoids adding go module files, which will be handled in a dedicated changeset.

## Design

Create a new interface for objects implementing `StackTrace()`, returning an [`errors.StackTrace`](https://godoc.org/github.com/pkg/errors#StackTrace) instance (which is an array of `uintptr` representing program counters). Given the array of program counters, the error can be processed normally.

## Changeset

* Added `errorWithStack` to represent the new error type (the `errors` package does not export this interface but it is listed as stable)

## Testing

* Added a new test for wrapping an `error` using the `errors.Wrap()` function, which generates a stack trace. This test verifies that the generated stack is used rather than creating a new one when `[bugsnag.]errors.New()` is called.