### PR TITLE
ci: configure gopath, check out source into path

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -6,6 +6,9 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 'go/src/github.com/bugsnag/bugsnag-go' # relative to $GITHUB_WORKSPACE
     strategy:
       fail-fast: false
       matrix:
@@ -13,11 +16,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        path: 'go/src/github.com/bugsnag/bugsnag-go' # relative to $GITHUB_WORKSPACE
     - name: setup go ${{ matrix.go-version }}
       run: |
         curl --silent --location --output gimme https://github.com/travis-ci/gimme/raw/v1.5.4/gimme
         chmod +x ./gimme
         eval "$(./gimme ${{ matrix.go-version }})"
+    - name: set GOPATH
+      run: echo "GOPATH=$GITHUB_WORKSPACE/go" >> $GITHUB_ENV
     - name: install dependencies
       run: make alldeps
     - name: run tests (go1.7 - go1.10)


### PR DESCRIPTION
Check out the source of the repository into a configured `$GOPATH`, instead of an arbitrary directory. This avoids situations where there might be a second copy on disk (and on a different branch) which might be referenced by subpackages or otherwise cause confusion.