### PR TITLE
feat: Support modifying events within a callback function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,15 @@
   bugsnag.Notify(err, func(event *bugsnag.Event) {
     event.ErrorClass = "Unexpected Termination"
     event.MetaData.Update(loadJobData())
+
+    if event.Stacktrace[0].File = "mylogger.go" {
+      event.Stacktrace = event.Stacktrace[1:]
+    }
   })
   ```
+
+  The stack trace of an event is now mutable so frames can be removed or
+  modified.
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 * Extract stacktrace contents on errors wrapped by
   [`pkg/errors`](https://github.com/pkg/errors).
+* Support modifying an individual event using a callback function argument.
+
+  ```go
+  bugsnag.Notify(err, func(event *bugsnag.Event) {
+    event.ErrorClass = "Unexpected Termination"
+    event.MetaData.Update(loadJobData())
+  })
+  ```
 
 ### Bug fixes
 

--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -132,7 +132,7 @@ func TestNotify(t *testing.T) {
 	}
 
 	exception := getIndex(event, "exceptions", 0)
-	verifyExistsInStackTrace(t, exception, &stackFrame{File: "bugsnag_test.go", Method: "TestNotify", LineNumber: 98, InProject: true})
+	verifyExistsInStackTrace(t, exception, &StackFrame{File: "bugsnag_test.go", Method: "TestNotify", LineNumber: 98, InProject: true})
 }
 
 type testPublisher struct {
@@ -315,7 +315,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	exception := getIndex(event, "exceptions", 0)
-	verifyExistsInStackTrace(t, exception, &stackFrame{File: "bugsnag_test.go", Method: "crashyHandler", InProject: true, LineNumber: 24})
+	verifyExistsInStackTrace(t, exception, &StackFrame{File: "bugsnag_test.go", Method: "crashyHandler", InProject: true, LineNumber: 24})
 }
 
 func TestAutoNotify(t *testing.T) {
@@ -611,7 +611,7 @@ func assertValidSession(t *testing.T, event *simplejson.Json, unhandled bool) {
 	}
 }
 
-func verifyExistsInStackTrace(t *testing.T, exception *simplejson.Json, exp *stackFrame) {
+func verifyExistsInStackTrace(t *testing.T, exception *simplejson.Json, exp *StackFrame) {
 	isFile := func(frame *simplejson.Json) bool { return strings.HasSuffix(getString(frame, "file"), exp.File) }
 	isMethod := func(frame *simplejson.Json) bool { return getString(frame, "method") == exp.Method }
 	isLineNumber := func(frame *simplejson.Json) bool { return getInt(frame, "lineNumber") == exp.LineNumber }

--- a/event.go
+++ b/event.go
@@ -43,7 +43,7 @@ type severity struct {
 }
 
 // The form of stacktrace that Bugsnag expects
-type stackFrame struct {
+type StackFrame struct {
 	Method     string `json:"method"`
 	File       string `json:"file"`
 	LineNumber int    `json:"lineNumber"`
@@ -85,7 +85,7 @@ type Event struct {
 	// The error message to be sent to Bugsnag. This defaults to the return value of Error.Error()
 	Message string
 	// The stacktrrace of the error to be sent to Bugsnag.
-	Stacktrace []stackFrame
+	Stacktrace []StackFrame
 
 	// The context to be sent to Bugsnag. This should be set to the part of the app that was running,
 	// e.g. for http requests, set it to the path.
@@ -136,7 +136,7 @@ func newEvent(rawData []interface{}, notifier *Notifier) (*Event, *Configuration
 				event.ErrorClass = err.TypeName()
 			}
 			event.Message = err.Error()
-			event.Stacktrace = make([]stackFrame, len(err.StackFrames()))
+			event.Stacktrace = make([]StackFrame, len(err.StackFrames()))
 
 		case bool:
 			config = config.merge(&Configuration{Synchronous: bool(datum)})
@@ -187,7 +187,7 @@ func newEvent(rawData []interface{}, notifier *Notifier) (*Event, *Configuration
 			file = config.stripProjectPackages(file)
 		}
 
-		event.Stacktrace[i] = stackFrame{
+		event.Stacktrace[i] = StackFrame{
 			Method:     frame.Name,
 			File:       file,
 			LineNumber: frame.LineNumber,

--- a/features/fixtures/app/main.go
+++ b/features/fixtures/app/main.go
@@ -238,6 +238,9 @@ func handledCallbackError() {
 	bugsnag.Notify(fmt.Errorf("Inadequent Prep Error"), func(event *bugsnag.Event) {
 		event.Context = "nonfatal.go:14"
 		event.Severity = bugsnag.SeverityInfo
+
+		event.Stacktrace[1].File = ">insertion<"
+		event.Stacktrace[1].LineNumber = 0
 	})
 	// Give some time for the error to be sent before exiting
 	time.Sleep(200 * time.Millisecond)

--- a/features/fixtures/app/main.go
+++ b/features/fixtures/app/main.go
@@ -76,6 +76,8 @@ func main() {
 		unhandledCrash()
 	case "handled", "endpoint legacy", "endpoint notify", "endpoint session":
 		handledError()
+	case "handled with callback":
+		handledCallbackError()
 	case "session":
 		session()
 	case "autonotify":
@@ -229,5 +231,14 @@ func user() {
 		Email: "test-user-email",
 	})
 
+	time.Sleep(200 * time.Millisecond)
+}
+
+func handledCallbackError() {
+	bugsnag.Notify(fmt.Errorf("Inadequent Prep Error"), func(event *bugsnag.Event) {
+		event.Context = "nonfatal.go:14"
+		event.Severity = bugsnag.SeverityInfo
+	})
+	// Give some time for the error to be sent before exiting
 	time.Sleep(200 * time.Millisecond)
 }

--- a/features/plain_features/handled.feature
+++ b/features/plain_features/handled.feature
@@ -37,3 +37,5 @@ Scenario: Sending an event using a callback to modify report contents
   And the event "context" equals "nonfatal.go:14"
   And the "file" of stack frame 0 equals "main.go"
   And stack frame 0 contains a local function spanning 238 to 244
+  And the "file" of stack frame 1 equals ">insertion<"
+  And the "lineNumber" of stack frame 1 equals 0

--- a/features/plain_features/handled.feature
+++ b/features/plain_features/handled.feature
@@ -26,3 +26,14 @@ Scenario: A handled error sends a report with a custom name
   And the event "severityReason.type" equals "handledError"
   And the exception "errorClass" equals "MyCustomErrorClass"
   And the "file" of stack frame 0 equals "main.go"
+
+Scenario: Sending an event using a callback to modify report contents
+  When I run the go service "app" with the test case "handled with callback"
+  Then I wait to receive a request
+  And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is false
+  And the event "severity" equals "info"
+  And the event "severityReason.type" equals "userCallbackSetSeverity"
+  And the event "context" equals "nonfatal.go:14"
+  And the "file" of stack frame 0 equals "main.go"
+  And stack frame 0 contains a local function spanning 238 to 244

--- a/features/steps/go_steps.rb
+++ b/features/steps/go_steps.rb
@@ -60,3 +60,12 @@ Then(/^I wait to receive (\d+) requests after the start up session?$/) do |reque
   sleep 1
   assert_equal(request_count, stored_requests.size, "#{stored_requests.size} requests received")
 end
+
+Then("stack frame {int} contains a local function spanning {int} to {int}") do |frame, val, old_val|
+  # Old versions of Go put the line number on the end of the function
+  if ['1.7', '1.8'].include? ENV['GO_VERSION']
+    step "the \"lineNumber\" of stack frame #{frame} equals #{old_val}"
+  else
+    step "the \"lineNumber\" of stack frame #{frame} equals #{val}"
+  end
+end

--- a/payload_test.go
+++ b/payload_test.go
@@ -43,7 +43,7 @@ func TestMarshalLargePayload(t *testing.T) {
 }
 
 func makeLargePayload() *payload {
-	stackframes := []stackFrame{
+	stackframes := []StackFrame{
 		{Method: "doA", File: "a.go", LineNumber: 65, InProject: false},
 		{Method: "fetchB", File: "b.go", LineNumber: 99, InProject: true},
 		{Method: "incrementI", File: "i.go", LineNumber: 651, InProject: false},

--- a/report.go
+++ b/report.go
@@ -49,7 +49,7 @@ type appJSON struct {
 type exceptionJSON struct {
 	ErrorClass string       `json:"errorClass"`
 	Message    string       `json:"message"`
-	Stacktrace []stackFrame `json:"stacktrace"`
+	Stacktrace []StackFrame `json:"stacktrace"`
 }
 
 type severityReasonJSON struct {


### PR DESCRIPTION
## Goal

Support passing a function to `Notify()` to allow modification of the complete event, including the stacktrace, on a per-invocation basis.

```go
bugsnag.Notify(err, func(event *bugsnag.Event) {
    event.Context = fmt.Printf("logger: %v", err)
})
```

## Design

Check for a function argument to `Notify()`, aggregating any found into a list which is called once the error is constructed. Like other arguments to `Notify()`, subsequent arguments can override previous ones, which is why the callbacks are stored as a collection rather than overriding a single instance.

The `StackFrame` structure is now public to support checking against or modifying stack frame contents. There's an example in the changelog for a common case: trimming stacktraces for functions routed through a logger or common error delivery point.

## Testing

* Tested manually that callbacks are executed and in order on multiple Go versions (1.8 and 1.15)
* Added new automated tests for common cases