### PR TITLE
Release v1.6.0

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -6,6 +6,9 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 'go/src/github.com/bugsnag/bugsnag-go' # relative to $GITHUB_WORKSPACE
     strategy:
       fail-fast: false
       matrix:
@@ -13,11 +16,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        path: 'go/src/github.com/bugsnag/bugsnag-go' # relative to $GITHUB_WORKSPACE
     - name: setup go ${{ matrix.go-version }}
       run: |
         curl --silent --location --output gimme https://github.com/travis-ci/gimme/raw/v1.5.4/gimme
         chmod +x ./gimme
         eval "$(./gimme ${{ matrix.go-version }})"
+    - name: set GOPATH
+      run: echo "GOPATH=$GITHUB_WORKSPACE/go" >> $GITHUB_ENV
     - name: install dependencies
       run: make alldeps
     - name: run tests (go1.7 - go1.10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## TBD
 
+### Enhancements
+
+* Extract stacktrace contents on errors wrapped by
+  [`pkg/errors`](https://github.com/pkg/errors).
+
 ### Bug fixes
 
 * Send web framework name with severity reason if set. Previously this value was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@
 
 * Extract stacktrace contents on errors wrapped by
   [`pkg/errors`](https://github.com/pkg/errors).
+* Support modifying an individual event using a callback function argument.
+
+  ```go
+  bugsnag.Notify(err, func(event *bugsnag.Event) {
+    event.ErrorClass = "Unexpected Termination"
+    event.MetaData.Update(loadJobData())
+
+    if event.Stacktrace[0].File = "mylogger.go" {
+      event.Stacktrace = event.Stacktrace[1:]
+    }
+  })
+  ```
+
+  The stack trace of an event is now mutable so frames can be removed or
+  modified.
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Send web framework name with severity reason if set. Previously this value was
+  ignored, obscuring the severity reason for failed web requests captured by
+  bugsnag middleware.
+
 ## 1.5.4 (2020-10-28)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## TBD
+## 1.6.0 (2020-11-12)
 
 ### Enhancements
 
 * Extract stacktrace contents on errors wrapped by
   [`pkg/errors`](https://github.com/pkg/errors).
+  [#144](https://github.com/bugsnag/bugsnag-go/pull/144)
 * Support modifying an individual event using a callback function argument.
 
   ```go
@@ -21,12 +22,14 @@
 
   The stack trace of an event is now mutable so frames can be removed or
   modified.
+  [#146](https://github.com/bugsnag/bugsnag-go/pull/146)
 
 ### Bug fixes
 
 * Send web framework name with severity reason if set. Previously this value was
   ignored, obscuring the severity reason for failed web requests captured by
   bugsnag middleware.
+  [#143](https://github.com/bugsnag/bugsnag-go/pull/143)
 
 ## 1.5.4 (2020-10-28)
 

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -21,7 +21,7 @@ import (
 )
 
 // VERSION defines the version of this Bugsnag notifier
-const VERSION = "1.5.4"
+const VERSION = "1.6.0"
 
 var panicHandlerOnce sync.Once
 var sessionTrackerOnce sync.Once

--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -132,7 +132,7 @@ func TestNotify(t *testing.T) {
 	}
 
 	exception := getIndex(event, "exceptions", 0)
-	verifyExistsInStackTrace(t, exception, &stackFrame{File: "bugsnag_test.go", Method: "TestNotify", LineNumber: 98, InProject: true})
+	verifyExistsInStackTrace(t, exception, &StackFrame{File: "bugsnag_test.go", Method: "TestNotify", LineNumber: 98, InProject: true})
 }
 
 type testPublisher struct {
@@ -315,7 +315,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	exception := getIndex(event, "exceptions", 0)
-	verifyExistsInStackTrace(t, exception, &stackFrame{File: "bugsnag_test.go", Method: "crashyHandler", InProject: true, LineNumber: 24})
+	verifyExistsInStackTrace(t, exception, &StackFrame{File: "bugsnag_test.go", Method: "crashyHandler", InProject: true, LineNumber: 24})
 }
 
 func TestAutoNotify(t *testing.T) {
@@ -611,7 +611,7 @@ func assertValidSession(t *testing.T, event *simplejson.Json, unhandled bool) {
 	}
 }
 
-func verifyExistsInStackTrace(t *testing.T, exception *simplejson.Json, exp *stackFrame) {
+func verifyExistsInStackTrace(t *testing.T, exception *simplejson.Json, exp *StackFrame) {
 	isFile := func(frame *simplejson.Json) bool { return strings.HasSuffix(getString(frame, "file"), exp.File) }
 	isMethod := func(frame *simplejson.Json) bool { return getString(frame, "method") == exp.Method }
 	isLineNumber := func(frame *simplejson.Json) bool { return getInt(frame, "lineNumber") == exp.LineNumber }

--- a/features/fixtures/app/main.go
+++ b/features/fixtures/app/main.go
@@ -76,6 +76,8 @@ func main() {
 		unhandledCrash()
 	case "handled", "endpoint legacy", "endpoint notify", "endpoint session":
 		handledError()
+	case "handled with callback":
+		handledCallbackError()
 	case "session":
 		session()
 	case "autonotify":
@@ -229,5 +231,17 @@ func user() {
 		Email: "test-user-email",
 	})
 
+	time.Sleep(200 * time.Millisecond)
+}
+
+func handledCallbackError() {
+	bugsnag.Notify(fmt.Errorf("Inadequent Prep Error"), func(event *bugsnag.Event) {
+		event.Context = "nonfatal.go:14"
+		event.Severity = bugsnag.SeverityInfo
+
+		event.Stacktrace[1].File = ">insertion<"
+		event.Stacktrace[1].LineNumber = 0
+	})
+	// Give some time for the error to be sent before exiting
 	time.Sleep(200 * time.Millisecond)
 }

--- a/features/gin_features/autonotify.feature
+++ b/features/gin_features/autonotify.feature
@@ -14,6 +14,8 @@ Scenario: An error report is sent when an AutoNotified crash occurs which later 
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is true
+  And the event "severityReason.type" equals "unhandledErrorMiddleware" for request 0
+  And the event "severityReason.attributes.framework" equals "Gin" for request 0
   And the exception "errorClass" equals "*runtime.TypeAssertionError"
   And the exception "message" matches "interface conversion: interface ({} )?is struct {}, not string"
 
@@ -26,5 +28,6 @@ Scenario: An error report is sent when a go routine crashes which is reported th
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is true
+  And the event "severityReason.type" equals "handledPanic" for request 0
   And the exception "errorClass" equals "*errors.errorString"
   And the exception "message" equals "Go routine killed with auto notify"

--- a/features/martini_features/autonotify.feature
+++ b/features/martini_features/autonotify.feature
@@ -14,6 +14,8 @@ Scenario: An error report is sent when an AutoNotified crash occurs which later 
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is true
+  And the event "severityReason.type" equals "unhandledErrorMiddleware" for request 0
+  And the event "severityReason.attributes.framework" equals "Martini" for request 0
   And the exception "errorClass" equals "*runtime.TypeAssertionError"
   And the exception "message" matches "interface conversion: interface ({} )?is struct {}, not string"
 
@@ -25,5 +27,6 @@ Scenario: An error report is sent when a go routine crashes which is reported th
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is true
+  And the event "severityReason.type" equals "handledPanic" for request 0
   And the exception "errorClass" equals "*errors.errorString"
   And the exception "message" equals "Go routine killed with auto notify"

--- a/features/negroni_features/autonotify.feature
+++ b/features/negroni_features/autonotify.feature
@@ -14,6 +14,8 @@ Scenario: An error report is sent when an AutoNotified crash occurs which later 
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is true
+  And the event "severityReason.type" equals "unhandledErrorMiddleware" for request 0
+  And the event "severityReason.attributes.framework" equals "Negroni" for request 0
   And the exception "errorClass" equals "*runtime.TypeAssertionError"
   And the exception "message" matches "interface conversion: interface ({} )?is struct {}, not string"
 
@@ -26,5 +28,6 @@ Scenario: An error report is sent when a go routine crashes which is reported th
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is true
+  And the event "severityReason.type" equals "handledPanic" for request 0
   And the exception "errorClass" equals "*errors.errorString"
   And the exception "message" equals "Go routine killed with auto notify"

--- a/features/plain_features/handled.feature
+++ b/features/plain_features/handled.feature
@@ -26,3 +26,16 @@ Scenario: A handled error sends a report with a custom name
   And the event "severityReason.type" equals "handledError"
   And the exception "errorClass" equals "MyCustomErrorClass"
   And the "file" of stack frame 0 equals "main.go"
+
+Scenario: Sending an event using a callback to modify report contents
+  When I run the go service "app" with the test case "handled with callback"
+  Then I wait to receive a request
+  And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is false
+  And the event "severity" equals "info"
+  And the event "severityReason.type" equals "userCallbackSetSeverity"
+  And the event "context" equals "nonfatal.go:14"
+  And the "file" of stack frame 0 equals "main.go"
+  And stack frame 0 contains a local function spanning 238 to 244
+  And the "file" of stack frame 1 equals ">insertion<"
+  And the "lineNumber" of stack frame 1 equals 0

--- a/features/revel_features/autonotify.feature
+++ b/features/revel_features/autonotify.feature
@@ -14,6 +14,8 @@ Scenario: An error report is sent when an AutoNotified crash occurs which later 
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is true
+  And the event "severityReason.type" equals "unhandledErrorMiddleware" for request 0
+  And the event "severityReason.attributes.framework" equals "Revel" for request 0
   And the exception "errorClass" equals "*runtime.TypeAssertionError"
   And the exception "message" matches "interface conversion: interface ({} )?is struct {}, not string"
 
@@ -26,5 +28,6 @@ Scenario: An error report is sent when a go routine crashes which is reported th
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is true
+  And the event "severityReason.type" equals "handledPanic" for request 0
   And the exception "errorClass" equals "*errors.errorString"
   And the exception "message" equals "Go routine killed with auto notify"

--- a/features/steps/go_steps.rb
+++ b/features/steps/go_steps.rb
@@ -60,3 +60,12 @@ Then(/^I wait to receive (\d+) requests after the start up session?$/) do |reque
   sleep 1
   assert_equal(request_count, stored_requests.size, "#{stored_requests.size} requests received")
 end
+
+Then("stack frame {int} contains a local function spanning {int} to {int}") do |frame, val, old_val|
+  # Old versions of Go put the line number on the end of the function
+  if ['1.7', '1.8'].include? ENV['GO_VERSION']
+    step "the \"lineNumber\" of stack frame #{frame} equals #{old_val}"
+  else
+    step "the \"lineNumber\" of stack frame #{frame} equals #{val}"
+  end
+end

--- a/payload.go
+++ b/payload.go
@@ -128,7 +128,12 @@ func (p *payload) makeSession() *sessionJSON {
 
 func (p *payload) severityReasonPayload() *severityReasonJSON {
 	if reason := p.handledState.SeverityReason; reason != "" {
-		return &severityReasonJSON{Type: reason}
+		json := &severityReasonJSON{Type: reason}
+		if p.handledState.Framework != "" {
+			json.Attributes = make(map[string]string, 1)
+			json.Attributes["framework"] = p.handledState.Framework
+		}
+		return json
 	}
 	return nil
 }

--- a/payload_test.go
+++ b/payload_test.go
@@ -43,7 +43,7 @@ func TestMarshalLargePayload(t *testing.T) {
 }
 
 func makeLargePayload() *payload {
-	stackframes := []stackFrame{
+	stackframes := []StackFrame{
 		{Method: "doA", File: "a.go", LineNumber: 65, InProject: false},
 		{Method: "fetchB", File: "b.go", LineNumber: 99, InProject: true},
 		{Method: "incrementI", File: "i.go", LineNumber: 651, InProject: false},

--- a/payload_test.go
+++ b/payload_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/bugsnag/bugsnag-go/sessions"
 )
 
-const expSmall = `{"apiKey":"","events":[{"app":{"releaseStage":""},"device":{"osName":"%s","runtimeVersions":{"go":"%s"}},"exceptions":[{"errorClass":"","message":"","stacktrace":null}],"metaData":{},"payloadVersion":"4","severity":"","unhandled":false}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.5.4"}}`
+const expSmall = `{"apiKey":"","events":[{"app":{"releaseStage":""},"device":{"osName":"%s","runtimeVersions":{"go":"%s"}},"exceptions":[{"errorClass":"","message":"","stacktrace":null}],"metaData":{},"payloadVersion":"4","severity":"","unhandled":false}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.6.0"}}`
 
 // The large payload has a timestamp in it which makes it awkward to assert against.
 // Instead, assert that the timestamp property exist, along with the rest of the expected payload
 const expLargePre = `{"apiKey":"166f5ad3590596f9aa8d601ea89af845","events":[{"app":{"releaseStage":"mega-production","type":"gin","version":"1.5.3"},"context":"/api/v2/albums","device":{"hostname":"super.duper.site","osName":"%s","runtimeVersions":{"go":"%s"}},"exceptions":[{"errorClass":"error class","message":"error message goes here","stacktrace":[{"method":"doA","file":"a.go","lineNumber":65},{"method":"fetchB","file":"b.go","lineNumber":99,"inProject":true},{"method":"incrementI","file":"i.go","lineNumber":651}]}],"groupingHash":"custom grouping hash","metaData":{"custom tab":{"my key":"my value"}},"payloadVersion":"4","session":{"startedAt":"`
-const expLargePost = `,"severity":"info","severityReason":{"type":"unhandledError","attributes":{"framework":"gin"}},"unhandled":true,"user":{"id":"1234baerg134","name":"Kool Kidz on da bus","email":"typo@busgang.com"}}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.5.4"}}`
+const expLargePost = `,"severity":"info","severityReason":{"type":"unhandledError","attributes":{"framework":"gin"}},"unhandled":true,"user":{"id":"1234baerg134","name":"Kool Kidz on da bus","email":"typo@busgang.com"}}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.6.0"}}`
 
 func TestMarshalEmptyPayload(t *testing.T) {
 	sessionTracker = sessions.NewSessionTracker(&sessionTrackingConfig)

--- a/payload_test.go
+++ b/payload_test.go
@@ -16,7 +16,7 @@ const expSmall = `{"apiKey":"","events":[{"app":{"releaseStage":""},"device":{"o
 // The large payload has a timestamp in it which makes it awkward to assert against.
 // Instead, assert that the timestamp property exist, along with the rest of the expected payload
 const expLargePre = `{"apiKey":"166f5ad3590596f9aa8d601ea89af845","events":[{"app":{"releaseStage":"mega-production","type":"gin","version":"1.5.3"},"context":"/api/v2/albums","device":{"hostname":"super.duper.site","osName":"%s","runtimeVersions":{"go":"%s"}},"exceptions":[{"errorClass":"error class","message":"error message goes here","stacktrace":[{"method":"doA","file":"a.go","lineNumber":65},{"method":"fetchB","file":"b.go","lineNumber":99,"inProject":true},{"method":"incrementI","file":"i.go","lineNumber":651}]}],"groupingHash":"custom grouping hash","metaData":{"custom tab":{"my key":"my value"}},"payloadVersion":"4","session":{"startedAt":"`
-const expLargePost = `,"severity":"info","severityReason":{"type":"unhandledError"},"unhandled":true,"user":{"id":"1234baerg134","name":"Kool Kidz on da bus","email":"typo@busgang.com"}}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.5.4"}}`
+const expLargePost = `,"severity":"info","severityReason":{"type":"unhandledError","attributes":{"framework":"gin"}},"unhandled":true,"user":{"id":"1234baerg134","name":"Kool Kidz on da bus","email":"typo@busgang.com"}}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.5.4"}}`
 
 func TestMarshalEmptyPayload(t *testing.T) {
 	sessionTracker = sessions.NewSessionTracker(&sessionTrackingConfig)

--- a/report.go
+++ b/report.go
@@ -49,7 +49,7 @@ type appJSON struct {
 type exceptionJSON struct {
 	ErrorClass string       `json:"errorClass"`
 	Message    string       `json:"message"`
-	Stacktrace []stackFrame `json:"stacktrace"`
+	Stacktrace []StackFrame `json:"stacktrace"`
 }
 
 type severityReasonJSON struct {

--- a/report.go
+++ b/report.go
@@ -53,7 +53,8 @@ type exceptionJSON struct {
 }
 
 type severityReasonJSON struct {
-	Type SeverityReason `json:"type,omitempty"`
+	Type                SeverityReason    `json:"type,omitempty"`
+	Attributes          map[string]string `json:"attributes,omitempty"`
 }
 
 type deviceJSON struct {


### PR DESCRIPTION
### Enhancements

* Extract stacktrace contents on errors wrapped by [`pkg/errors`](https://github.com/pkg/errors).
  [#144](https://github.com/bugsnag/bugsnag-go/pull/144)
* Support modifying an individual event using a callback function argument.

  ```go
  bugsnag.Notify(err, func(event *bugsnag.Event) {
    event.ErrorClass = "Unexpected Termination"
    event.MetaData.Update(loadJobData())

    if event.Stacktrace[0].File = "mylogger.go" {
      event.Stacktrace = event.Stacktrace[1:]
    }
  })
  ```

  The stack trace of an event is now mutable so frames can be removed or modified.
  [#146](https://github.com/bugsnag/bugsnag-go/pull/146)

### Bug fixes

* Send web framework name with severity reason if set. Previously this value was ignored, obscuring the severity reason for failed web requests captured by bugsnag middleware.
  [#143](https://github.com/bugsnag/bugsnag-go/pull/143)
