### PR TITLE
feat: support modifying handled-ness in callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Support for changing the handled-ness of an event prior to delivery. This
+  allows for otherwise handled events to affect a project's stability score.
+
+  ```go
+  bugsnag.Notify(err, func(event *bugsnag.Event) {
+    event.Unhandled = true
+  })
+  ```
+
 ## 1.6.0 (2020-11-12)
 
 ### Enhancements

--- a/event.go
+++ b/event.go
@@ -106,6 +106,8 @@ type Event struct {
 	Request *RequestJSON
 	// The reason for the severity and original value
 	handledState HandledState
+	// True if the event was caused by an automatic event
+	Unhandled bool
 }
 
 func newEvent(rawData []interface{}, notifier *Notifier) (*Event, *Configuration) {
@@ -120,6 +122,7 @@ func newEvent(rawData []interface{}, notifier *Notifier) (*Event, *Configuration
 			Unhandled:        false,
 			Framework:        "",
 		},
+		Unhandled: false,
 	}
 
 	var err *errors.Error
@@ -170,6 +173,7 @@ func newEvent(rawData []interface{}, notifier *Notifier) (*Event, *Configuration
 		case HandledState:
 			event.handledState = datum
 			event.Severity = datum.OriginalSeverity
+			event.Unhandled = datum.Unhandled
 		case func(*Event):
 			callbacks = append(callbacks, datum)
 		}

--- a/features/fixtures/app/main.go
+++ b/features/fixtures/app/main.go
@@ -100,6 +100,8 @@ func main() {
 		multipleHandled()
 	case "multiple unhandled":
 		multipleUnhandled()
+	case "make unhandled with callback":
+		handledToUnhandled()
 	default:
 		log.Println("Not a valid test flag: " + *test)
 		os.Exit(1)
@@ -241,6 +243,15 @@ func handledCallbackError() {
 
 		event.Stacktrace[1].File = ">insertion<"
 		event.Stacktrace[1].LineNumber = 0
+	})
+	// Give some time for the error to be sent before exiting
+	time.Sleep(200 * time.Millisecond)
+}
+
+func handledToUnhandled() {
+	bugsnag.Notify(fmt.Errorf("unknown event"), func(event *bugsnag.Event) {
+		event.Unhandled = true
+		event.Severity = bugsnag.SeverityError
 	})
 	// Give some time for the error to be sent before exiting
 	time.Sleep(200 * time.Millisecond)

--- a/features/plain_features/handled.feature
+++ b/features/plain_features/handled.feature
@@ -36,6 +36,17 @@ Scenario: Sending an event using a callback to modify report contents
   And the event "severityReason.type" equals "userCallbackSetSeverity"
   And the event "context" equals "nonfatal.go:14"
   And the "file" of stack frame 0 equals "main.go"
-  And stack frame 0 contains a local function spanning 238 to 244
+  And stack frame 0 contains a local function spanning 240 to 246
   And the "file" of stack frame 1 equals ">insertion<"
   And the "lineNumber" of stack frame 1 equals 0
+
+Scenario: Marking an error as unhandled in a callback
+  When I run the go service "app" with the test case "make unhandled with callback"
+  Then I wait to receive a request
+  And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is true
+  And the event "severity" equals "error"
+  And the event "severityReason.type" equals "userCallbackSetSeverity"
+  And the event "severityReason.unhandledOverridden" is true
+  And the "file" of stack frame 0 equals "main.go"
+  And stack frame 0 contains a local function spanning 252 to 255

--- a/payload.go
+++ b/payload.go
@@ -90,7 +90,7 @@ func (p *payload) MarshalJSON() ([]byte, error) {
 				Session:        p.makeSession(),
 				Severity:       p.Severity.String,
 				SeverityReason: p.severityReasonPayload(),
-				Unhandled:      p.handledState.Unhandled,
+				Unhandled:      p.Unhandled,
 				User:           p.User,
 			},
 		},
@@ -111,7 +111,7 @@ func (p *payload) makeSession() *sessionJSON {
 
 	sessionMutex.Lock()
 	defer sessionMutex.Unlock()
-	session := sessions.IncrementEventCountAndGetSession(p.Ctx, p.handledState.Unhandled)
+	session := sessions.IncrementEventCountAndGetSession(p.Ctx, p.Unhandled)
 	if session != nil {
 		s := *session
 		return &sessionJSON{
@@ -128,7 +128,10 @@ func (p *payload) makeSession() *sessionJSON {
 
 func (p *payload) severityReasonPayload() *severityReasonJSON {
 	if reason := p.handledState.SeverityReason; reason != "" {
-		json := &severityReasonJSON{Type: reason}
+		json := &severityReasonJSON{
+			Type: reason,
+			UnhandledOverridden: p.handledState.Unhandled != p.Unhandled,
+		}
 		if p.handledState.Framework != "" {
 			json.Attributes = make(map[string]string, 1)
 			json.Attributes["framework"] = p.handledState.Framework

--- a/payload_test.go
+++ b/payload_test.go
@@ -79,6 +79,7 @@ func makeLargePayload() *payload {
 				"my key": "my value",
 			},
 		},
+		Unhandled: true,
 		handledState: handledState,
 	}
 	config := Configuration{

--- a/report.go
+++ b/report.go
@@ -55,6 +55,7 @@ type exceptionJSON struct {
 type severityReasonJSON struct {
 	Type                SeverityReason    `json:"type,omitempty"`
 	Attributes          map[string]string `json:"attributes,omitempty"`
+	UnhandledOverridden bool              `json:"unhandledOverridden,omitempty"`
 }
 
 type deviceJSON struct {


### PR DESCRIPTION
## Changeset

* Add `Unhandled` property to event. The default value is the `Unhandled`	value of `handledState`, which is otherwise immutable. This allows for tracking when the value has been changed (assuming that if one callback changes the value, and another changes it back, the change didn't matter).

## Testing

* Tested manually to verify dashboard appearance as well as adding new automated tests to ensure `unhandledOverridden` is only sent when true.