### PR TITLE
Release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Support for changing the handled-ness of an event prior to delivery. This
+  allows for otherwise handled events to affect a project's stability score.
+
+  ```go
+  bugsnag.Notify(err, func(event *bugsnag.Event) {
+    event.Unhandled = true
+  })
+  ```
+
 ## 1.6.0 (2020-11-12)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## 1.7.0 (2020-11-18)
 
 ### Enhancements
 

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -21,7 +21,7 @@ import (
 )
 
 // VERSION defines the version of this Bugsnag notifier
-const VERSION = "1.6.0"
+const VERSION = "1.7.0"
 
 var panicHandlerOnce sync.Once
 var sessionTrackerOnce sync.Once

--- a/event.go
+++ b/event.go
@@ -106,6 +106,8 @@ type Event struct {
 	Request *RequestJSON
 	// The reason for the severity and original value
 	handledState HandledState
+	// True if the event was caused by an automatic event
+	Unhandled bool
 }
 
 func newEvent(rawData []interface{}, notifier *Notifier) (*Event, *Configuration) {
@@ -120,6 +122,7 @@ func newEvent(rawData []interface{}, notifier *Notifier) (*Event, *Configuration
 			Unhandled:        false,
 			Framework:        "",
 		},
+		Unhandled: false,
 	}
 
 	var err *errors.Error
@@ -170,6 +173,7 @@ func newEvent(rawData []interface{}, notifier *Notifier) (*Event, *Configuration
 		case HandledState:
 			event.handledState = datum
 			event.Severity = datum.OriginalSeverity
+			event.Unhandled = datum.Unhandled
 		case func(*Event):
 			callbacks = append(callbacks, datum)
 		}

--- a/features/fixtures/app/main.go
+++ b/features/fixtures/app/main.go
@@ -100,6 +100,8 @@ func main() {
 		multipleHandled()
 	case "multiple unhandled":
 		multipleUnhandled()
+	case "make unhandled with callback":
+		handledToUnhandled()
 	default:
 		log.Println("Not a valid test flag: " + *test)
 		os.Exit(1)
@@ -241,6 +243,15 @@ func handledCallbackError() {
 
 		event.Stacktrace[1].File = ">insertion<"
 		event.Stacktrace[1].LineNumber = 0
+	})
+	// Give some time for the error to be sent before exiting
+	time.Sleep(200 * time.Millisecond)
+}
+
+func handledToUnhandled() {
+	bugsnag.Notify(fmt.Errorf("unknown event"), func(event *bugsnag.Event) {
+		event.Unhandled = true
+		event.Severity = bugsnag.SeverityError
 	})
 	// Give some time for the error to be sent before exiting
 	time.Sleep(200 * time.Millisecond)

--- a/features/plain_features/handled.feature
+++ b/features/plain_features/handled.feature
@@ -36,6 +36,17 @@ Scenario: Sending an event using a callback to modify report contents
   And the event "severityReason.type" equals "userCallbackSetSeverity"
   And the event "context" equals "nonfatal.go:14"
   And the "file" of stack frame 0 equals "main.go"
-  And stack frame 0 contains a local function spanning 238 to 244
+  And stack frame 0 contains a local function spanning 240 to 246
   And the "file" of stack frame 1 equals ">insertion<"
   And the "lineNumber" of stack frame 1 equals 0
+
+Scenario: Marking an error as unhandled in a callback
+  When I run the go service "app" with the test case "make unhandled with callback"
+  Then I wait to receive a request
+  And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is true
+  And the event "severity" equals "error"
+  And the event "severityReason.type" equals "userCallbackSetSeverity"
+  And the event "severityReason.unhandledOverridden" is true
+  And the "file" of stack frame 0 equals "main.go"
+  And stack frame 0 contains a local function spanning 252 to 255

--- a/payload.go
+++ b/payload.go
@@ -90,7 +90,7 @@ func (p *payload) MarshalJSON() ([]byte, error) {
 				Session:        p.makeSession(),
 				Severity:       p.Severity.String,
 				SeverityReason: p.severityReasonPayload(),
-				Unhandled:      p.handledState.Unhandled,
+				Unhandled:      p.Unhandled,
 				User:           p.User,
 			},
 		},
@@ -111,7 +111,7 @@ func (p *payload) makeSession() *sessionJSON {
 
 	sessionMutex.Lock()
 	defer sessionMutex.Unlock()
-	session := sessions.IncrementEventCountAndGetSession(p.Ctx, p.handledState.Unhandled)
+	session := sessions.IncrementEventCountAndGetSession(p.Ctx, p.Unhandled)
 	if session != nil {
 		s := *session
 		return &sessionJSON{
@@ -128,7 +128,10 @@ func (p *payload) makeSession() *sessionJSON {
 
 func (p *payload) severityReasonPayload() *severityReasonJSON {
 	if reason := p.handledState.SeverityReason; reason != "" {
-		json := &severityReasonJSON{Type: reason}
+		json := &severityReasonJSON{
+			Type: reason,
+			UnhandledOverridden: p.handledState.Unhandled != p.Unhandled,
+		}
 		if p.handledState.Framework != "" {
 			json.Attributes = make(map[string]string, 1)
 			json.Attributes["framework"] = p.handledState.Framework

--- a/payload_test.go
+++ b/payload_test.go
@@ -79,6 +79,7 @@ func makeLargePayload() *payload {
 				"my key": "my value",
 			},
 		},
+		Unhandled: true,
 		handledState: handledState,
 	}
 	config := Configuration{

--- a/payload_test.go
+++ b/payload_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/bugsnag/bugsnag-go/sessions"
 )
 
-const expSmall = `{"apiKey":"","events":[{"app":{"releaseStage":""},"device":{"osName":"%s","runtimeVersions":{"go":"%s"}},"exceptions":[{"errorClass":"","message":"","stacktrace":null}],"metaData":{},"payloadVersion":"4","severity":"","unhandled":false}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.6.0"}}`
+const expSmall = `{"apiKey":"","events":[{"app":{"releaseStage":""},"device":{"osName":"%s","runtimeVersions":{"go":"%s"}},"exceptions":[{"errorClass":"","message":"","stacktrace":null}],"metaData":{},"payloadVersion":"4","severity":"","unhandled":false}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.7.0"}}`
 
 // The large payload has a timestamp in it which makes it awkward to assert against.
 // Instead, assert that the timestamp property exist, along with the rest of the expected payload
 const expLargePre = `{"apiKey":"166f5ad3590596f9aa8d601ea89af845","events":[{"app":{"releaseStage":"mega-production","type":"gin","version":"1.5.3"},"context":"/api/v2/albums","device":{"hostname":"super.duper.site","osName":"%s","runtimeVersions":{"go":"%s"}},"exceptions":[{"errorClass":"error class","message":"error message goes here","stacktrace":[{"method":"doA","file":"a.go","lineNumber":65},{"method":"fetchB","file":"b.go","lineNumber":99,"inProject":true},{"method":"incrementI","file":"i.go","lineNumber":651}]}],"groupingHash":"custom grouping hash","metaData":{"custom tab":{"my key":"my value"}},"payloadVersion":"4","session":{"startedAt":"`
-const expLargePost = `,"severity":"info","severityReason":{"type":"unhandledError","attributes":{"framework":"gin"}},"unhandled":true,"user":{"id":"1234baerg134","name":"Kool Kidz on da bus","email":"typo@busgang.com"}}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.6.0"}}`
+const expLargePost = `,"severity":"info","severityReason":{"type":"unhandledError","attributes":{"framework":"gin"}},"unhandled":true,"user":{"id":"1234baerg134","name":"Kool Kidz on da bus","email":"typo@busgang.com"}}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.7.0"}}`
 
 func TestMarshalEmptyPayload(t *testing.T) {
 	sessionTracker = sessions.NewSessionTracker(&sessionTrackingConfig)

--- a/report.go
+++ b/report.go
@@ -55,6 +55,7 @@ type exceptionJSON struct {
 type severityReasonJSON struct {
 	Type                SeverityReason    `json:"type,omitempty"`
 	Attributes          map[string]string `json:"attributes,omitempty"`
+	UnhandledOverridden bool              `json:"unhandledOverridden,omitempty"`
 }
 
 type deviceJSON struct {


### PR DESCRIPTION
### Enhancements

* Support for changing the handled-ness of an event prior to delivery. This
  allows for otherwise handled events to affect a project's stability score.

  ```go
  bugsnag.Notify(err, func(event *bugsnag.Event) {
    event.Unhandled = true
  })
  ```