### PR TITLE
feat: Support unwrapping causes from errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Support unwrapping the underlying causes from an error, including attached
+  stack trace contents if available.
+
+  Any reported error which implements the following interface:
+
+  ```go
+  type errorWithCause interface {
+    Unwrap() error
+  }
+  ```
+
+  will have the cause included as a previous error in the resulting event. The
+  cause information will be available on the Bugsnag dashboard and is available
+  for inspection in callbacks on the `errors.Error` object.
+
+  ```go
+  bugsnag.OnBeforeNotify(func(event *bugsnag.Event, config *bugsnag.Configuration) error {
+    if event.Error.Cause != nil {
+      fmt.Printf("This error was caused by %v", event.Error.Cause.Error())
+    }
+    return nil
+  })
+  ```
+
 ## 1.7.0 (2020-11-18)
 
 ### Enhancements

--- a/features/fixtures/app/main.go
+++ b/features/fixtures/app/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -102,6 +103,8 @@ func main() {
 		multipleUnhandled()
 	case "make unhandled with callback":
 		handledToUnhandled()
+	case "nested error":
+		nestedHandledError()
 	default:
 		log.Println("Not a valid test flag: " + *test)
 		os.Exit(1)
@@ -255,4 +258,72 @@ func handledToUnhandled() {
 	})
 	// Give some time for the error to be sent before exiting
 	time.Sleep(200 * time.Millisecond)
+}
+
+type customErr struct {
+	msg string
+	cause error
+	callers []uintptr
+}
+
+func newCustomErr(msg string, cause error) error {
+	callers := make([]uintptr, 8)
+	runtime.Callers(2, callers)
+	return customErr {
+		msg: msg,
+		cause: cause,
+		callers: callers,
+	}
+}
+
+func (err customErr) Error() string {
+	return err.msg
+}
+
+func (err customErr) Unwrap() error {
+	return err.cause
+}
+
+func (err customErr) Callers() []uintptr {
+	return err.callers
+}
+
+func nestedHandledError() {
+	if err := login("token " + os.Getenv("API_KEY")); err != nil {
+		bugsnag.Notify(newCustomErr("terminate process", err))
+		// Give some time for the error to be sent before exiting
+		time.Sleep(200 * time.Millisecond)
+	} else {
+		i := len(os.Getenv("API_KEY"))
+		// Some nonsense to avoid inlining checkValue
+		if val, err := checkValue(i); err != nil {
+			fmt.Printf("err: %v, val: %d", err, val)
+		}
+		if val, err := checkValue(i-46); err != nil {
+			fmt.Printf("err: %v, val: %d", err, val)
+		}
+
+		log.Fatalf("This test is broken - no error was generated.")
+	}
+}
+
+func login(token string) error {
+	val, err := checkValue(len(token) * -1)
+	if err != nil {
+		return newCustomErr("login failed", err)
+	}
+	fmt.Printf("val: %d", val)
+	return nil
+}
+
+func checkValue(i int) (int, error) {
+	if i < 0 {
+		return 0, newCustomErr("invalid token", nil)
+	} else if i % 2 == 0 {
+		return i / 2, nil
+	} else if i < 9 {
+		return i * 3, nil
+	}
+
+	return i * 4, nil
 }

--- a/features/plain_features/handled.feature
+++ b/features/plain_features/handled.feature
@@ -36,7 +36,7 @@ Scenario: Sending an event using a callback to modify report contents
   And the event "severityReason.type" equals "userCallbackSetSeverity"
   And the event "context" equals "nonfatal.go:14"
   And the "file" of stack frame 0 equals "main.go"
-  And stack frame 0 contains a local function spanning 240 to 246
+  And stack frame 0 contains a local function spanning 243 to 249
   And the "file" of stack frame 1 equals ">insertion<"
   And the "lineNumber" of stack frame 1 equals 0
 
@@ -49,4 +49,21 @@ Scenario: Marking an error as unhandled in a callback
   And the event "severityReason.type" equals "userCallbackSetSeverity"
   And the event "severityReason.unhandledOverridden" is true
   And the "file" of stack frame 0 equals "main.go"
-  And stack frame 0 contains a local function spanning 252 to 255
+  And stack frame 0 contains a local function spanning 255 to 258
+
+Scenario: Unwrapping the causes of a handled error
+  When I run the go service "app" with the test case "nested error"
+  Then I wait to receive a request
+  And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is false
+  And the event "severity" equals "warning"
+  And the event "exceptions.0.message" equals "terminate process"
+  And the "lineNumber" of stack frame 0 equals 293
+  And the "file" of stack frame 0 equals "main.go"
+  And the "method" of stack frame 0 equals "nestedHandledError"
+  And the event "exceptions.1.message" equals "login failed"
+  And the event "exceptions.1.stacktrace.0.file" equals "main.go"
+  And the event "exceptions.1.stacktrace.0.lineNumber" equals 313
+  And the event "exceptions.2.message" equals "invalid token"
+  And the event "exceptions.2.stacktrace.0.file" equals "main.go"
+  And the event "exceptions.2.stacktrace.0.lineNumber" equals 321

--- a/payload.go
+++ b/payload.go
@@ -144,6 +144,19 @@ func (p *payload) exceptions() []exceptionJSON {
 		},
 	}
 
+	if p.Error == nil {
+		return exceptions
+	}
+
+	cause := p.Error.Cause
+	for cause != nil {
+		exceptions = append(exceptions, exceptionJSON{
+			ErrorClass: cause.TypeName(),
+			Message:    cause.Error(),
+			Stacktrace: generateStacktrace(cause, p.Configuration),
+		})
+		cause = cause.Cause
+	}
 
 	return exceptions
 }

--- a/payload.go
+++ b/payload.go
@@ -77,13 +77,7 @@ func (p *payload) MarshalJSON() ([]byte, error) {
 					RuntimeVersions: device.GetRuntimeVersions(),
 				},
 				Request: p.Request,
-				Exceptions: []exceptionJSON{
-					exceptionJSON{
-						ErrorClass: p.ErrorClass,
-						Message:    p.Message,
-						Stacktrace: p.Stacktrace,
-					},
-				},
+				Exceptions:     p.exceptions(),
 				GroupingHash:   p.GroupingHash,
 				Metadata:       p.MetaData.sanitize(p.ParamsFilters),
 				PayloadVersion: notifyPayloadVersion,
@@ -139,4 +133,17 @@ func (p *payload) severityReasonPayload() *severityReasonJSON {
 		return json
 	}
 	return nil
+}
+
+func (p *payload) exceptions() []exceptionJSON {
+	exceptions := []exceptionJSON{
+		exceptionJSON{
+			ErrorClass: p.ErrorClass,
+			Message:    p.Message,
+			Stacktrace: p.Stacktrace,
+		},
+	}
+
+
+	return exceptions
 }


### PR DESCRIPTION
## Goal

Including the contents of errors which are wrapped by later errors. When a new error is generated from an earlier error to add additional context, the nested error (and associated message and/or stack trace contents) is lost. This change attempts to fix this by attaching each unwrapped error as a cause.

## Design


Any reported error which implements the following interface:

```go
type errorWithCause interface {
    Cause() error
}
```

will have the cause included as a previous error in the resulting event. The cause information will be available on the Bugsnag dashboard and is available for inspection in callbacks on the `errors.Error` object.

Given the following error implementation:

<details>
<summary>Example error implementation</summary>

```go
package main

import (
	"runtime"
)

type customErr struct {
	msg string
	cause error
	callers []uintptr
}

func newCustomErr(msg string, cause error) error {
	callers := make([]uintptr, 8)
	runtime.Callers(2, callers)
	return customErr {
		msg: msg,
		cause: cause,
		callers: callers,
	}
}

func (err customErr) Error() string {
	return err.msg
}

func (err customErr) Cause() error {
	return err.cause
}

func (err customErr) Callers() []uintptr {
	return err.callers
}
```

</details>

and example usage:

<details>
<summary>Sample app</summary>

```go
package main

import (
	"net/http"
	"os"

	"github.com/bugsnag/bugsnag-go"
)

func main() {
	bugsnag.Configure(bugsnag.Configuration{APIKey: os.Getenv("BUGSNAG_API_KEY"})
	http.HandleFunc("/", handledError)
	http.ListenAndServe(":9001", bugsnag.Handler(nil))
}

func handledError(w http.ResponseWriter, r *http.Request) {
	messages := make(chan error)

	loadFile(messages, "nonexistent_file.txt")
	err := <-messages
	if err != nil {
		bugsnag.Notify(newCustomErr("incorrect permissions", err), r.Context())
	}
}

func loadFile(queue chan error, path string) error {
	go func() {
		_, err := os.Open(path)
		if err != nil {
			queue <- newCustomErr("file missing?", err)
		}
	}()

	return nil
}
```

</details>

After calling the default route of the app, the Bugsnag dashboard shows the initial and intermediate errors leading to the one which was reported.

### Screenshots

Standard view:
<img width="548" alt="standard view" src="https://user-images.githubusercontent.com/333454/99832221-20a91380-2b58-11eb-9414-a1a456c0b723.png">

Full trace:
<img width="517" alt="full view" src="https://user-images.githubusercontent.com/333454/99832225-21da4080-2b58-11eb-958a-c7aebbc297f9.png">

Raw trace:
<img width="668" alt="raw view" src="https://user-images.githubusercontent.com/333454/99832229-230b6d80-2b58-11eb-906a-df5fed044be7.png">


## Changeset

* Refactored `newEvent` to make the stacktrace parsing reusable
* Refactored JSON marshaling to support reporting multiple exceptions
* Added `errors.Error.Cause` - this is a pointer to an `Error`, only set if a cause was detected. The cause value is inspectable/modifiable from callback functions.

## Testing

* Added new tests for unwrapping errors with and without stack traces