### PR TITLE
release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## 1.8.0 (2020-12-03)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Support unwrapping the underlying causes from an error, including attached
+  stack trace contents if available.
+
+  Any reported error which implements the following interface:
+
+  ```go
+  type errorWithCause interface {
+    Unwrap() error
+  }
+  ```
+
+  will have the cause included as a previous error in the resulting event. The
+  cause information will be available on the Bugsnag dashboard and is available
+  for inspection in callbacks on the `errors.Error` object.
+
+  ```go
+  bugsnag.OnBeforeNotify(func(event *bugsnag.Event, config *bugsnag.Configuration) error {
+    if event.Error.Cause != nil {
+      fmt.Printf("This error was caused by %v", event.Error.Cause.Error())
+    }
+    return nil
+  })
+  ```
+
 ## 1.7.0 (2020-11-18)
 
 ### Enhancements

--- a/bugsnag.go
+++ b/bugsnag.go
@@ -21,7 +21,7 @@ import (
 )
 
 // VERSION defines the version of this Bugsnag notifier
-const VERSION = "1.7.0"
+const VERSION = "1.8.0"
 
 var panicHandlerOnce sync.Once
 var sessionTrackerOnce sync.Once

--- a/features/fixtures/app/main.go
+++ b/features/fixtures/app/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -102,6 +103,8 @@ func main() {
 		multipleUnhandled()
 	case "make unhandled with callback":
 		handledToUnhandled()
+	case "nested error":
+		nestedHandledError()
 	default:
 		log.Println("Not a valid test flag: " + *test)
 		os.Exit(1)
@@ -255,4 +258,72 @@ func handledToUnhandled() {
 	})
 	// Give some time for the error to be sent before exiting
 	time.Sleep(200 * time.Millisecond)
+}
+
+type customErr struct {
+	msg string
+	cause error
+	callers []uintptr
+}
+
+func newCustomErr(msg string, cause error) error {
+	callers := make([]uintptr, 8)
+	runtime.Callers(2, callers)
+	return customErr {
+		msg: msg,
+		cause: cause,
+		callers: callers,
+	}
+}
+
+func (err customErr) Error() string {
+	return err.msg
+}
+
+func (err customErr) Unwrap() error {
+	return err.cause
+}
+
+func (err customErr) Callers() []uintptr {
+	return err.callers
+}
+
+func nestedHandledError() {
+	if err := login("token " + os.Getenv("API_KEY")); err != nil {
+		bugsnag.Notify(newCustomErr("terminate process", err))
+		// Give some time for the error to be sent before exiting
+		time.Sleep(200 * time.Millisecond)
+	} else {
+		i := len(os.Getenv("API_KEY"))
+		// Some nonsense to avoid inlining checkValue
+		if val, err := checkValue(i); err != nil {
+			fmt.Printf("err: %v, val: %d", err, val)
+		}
+		if val, err := checkValue(i-46); err != nil {
+			fmt.Printf("err: %v, val: %d", err, val)
+		}
+
+		log.Fatalf("This test is broken - no error was generated.")
+	}
+}
+
+func login(token string) error {
+	val, err := checkValue(len(token) * -1)
+	if err != nil {
+		return newCustomErr("login failed", err)
+	}
+	fmt.Printf("val: %d", val)
+	return nil
+}
+
+func checkValue(i int) (int, error) {
+	if i < 0 {
+		return 0, newCustomErr("invalid token", nil)
+	} else if i % 2 == 0 {
+		return i / 2, nil
+	} else if i < 9 {
+		return i * 3, nil
+	}
+
+	return i * 4, nil
 }

--- a/features/plain_features/handled.feature
+++ b/features/plain_features/handled.feature
@@ -36,7 +36,7 @@ Scenario: Sending an event using a callback to modify report contents
   And the event "severityReason.type" equals "userCallbackSetSeverity"
   And the event "context" equals "nonfatal.go:14"
   And the "file" of stack frame 0 equals "main.go"
-  And stack frame 0 contains a local function spanning 240 to 246
+  And stack frame 0 contains a local function spanning 243 to 249
   And the "file" of stack frame 1 equals ">insertion<"
   And the "lineNumber" of stack frame 1 equals 0
 
@@ -49,4 +49,21 @@ Scenario: Marking an error as unhandled in a callback
   And the event "severityReason.type" equals "userCallbackSetSeverity"
   And the event "severityReason.unhandledOverridden" is true
   And the "file" of stack frame 0 equals "main.go"
-  And stack frame 0 contains a local function spanning 252 to 255
+  And stack frame 0 contains a local function spanning 255 to 258
+
+Scenario: Unwrapping the causes of a handled error
+  When I run the go service "app" with the test case "nested error"
+  Then I wait to receive a request
+  And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event "unhandled" is false
+  And the event "severity" equals "warning"
+  And the event "exceptions.0.message" equals "terminate process"
+  And the "lineNumber" of stack frame 0 equals 293
+  And the "file" of stack frame 0 equals "main.go"
+  And the "method" of stack frame 0 equals "nestedHandledError"
+  And the event "exceptions.1.message" equals "login failed"
+  And the event "exceptions.1.stacktrace.0.file" equals "main.go"
+  And the event "exceptions.1.stacktrace.0.lineNumber" equals 313
+  And the event "exceptions.2.message" equals "invalid token"
+  And the event "exceptions.2.stacktrace.0.file" equals "main.go"
+  And the event "exceptions.2.stacktrace.0.lineNumber" equals 321

--- a/payload.go
+++ b/payload.go
@@ -77,13 +77,7 @@ func (p *payload) MarshalJSON() ([]byte, error) {
 					RuntimeVersions: device.GetRuntimeVersions(),
 				},
 				Request: p.Request,
-				Exceptions: []exceptionJSON{
-					exceptionJSON{
-						ErrorClass: p.ErrorClass,
-						Message:    p.Message,
-						Stacktrace: p.Stacktrace,
-					},
-				},
+				Exceptions:     p.exceptions(),
 				GroupingHash:   p.GroupingHash,
 				Metadata:       p.MetaData.sanitize(p.ParamsFilters),
 				PayloadVersion: notifyPayloadVersion,
@@ -139,4 +133,30 @@ func (p *payload) severityReasonPayload() *severityReasonJSON {
 		return json
 	}
 	return nil
+}
+
+func (p *payload) exceptions() []exceptionJSON {
+	exceptions := []exceptionJSON{
+		exceptionJSON{
+			ErrorClass: p.ErrorClass,
+			Message:    p.Message,
+			Stacktrace: p.Stacktrace,
+		},
+	}
+
+	if p.Error == nil {
+		return exceptions
+	}
+
+	cause := p.Error.Cause
+	for cause != nil {
+		exceptions = append(exceptions, exceptionJSON{
+			ErrorClass: cause.TypeName(),
+			Message:    cause.Error(),
+			Stacktrace: generateStacktrace(cause, p.Configuration),
+		})
+		cause = cause.Cause
+	}
+
+	return exceptions
 }

--- a/payload_test.go
+++ b/payload_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/bugsnag/bugsnag-go/sessions"
 )
 
-const expSmall = `{"apiKey":"","events":[{"app":{"releaseStage":""},"device":{"osName":"%s","runtimeVersions":{"go":"%s"}},"exceptions":[{"errorClass":"","message":"","stacktrace":null}],"metaData":{},"payloadVersion":"4","severity":"","unhandled":false}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.7.0"}}`
+const expSmall = `{"apiKey":"","events":[{"app":{"releaseStage":""},"device":{"osName":"%s","runtimeVersions":{"go":"%s"}},"exceptions":[{"errorClass":"","message":"","stacktrace":null}],"metaData":{},"payloadVersion":"4","severity":"","unhandled":false}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.8.0"}}`
 
 // The large payload has a timestamp in it which makes it awkward to assert against.
 // Instead, assert that the timestamp property exist, along with the rest of the expected payload
 const expLargePre = `{"apiKey":"166f5ad3590596f9aa8d601ea89af845","events":[{"app":{"releaseStage":"mega-production","type":"gin","version":"1.5.3"},"context":"/api/v2/albums","device":{"hostname":"super.duper.site","osName":"%s","runtimeVersions":{"go":"%s"}},"exceptions":[{"errorClass":"error class","message":"error message goes here","stacktrace":[{"method":"doA","file":"a.go","lineNumber":65},{"method":"fetchB","file":"b.go","lineNumber":99,"inProject":true},{"method":"incrementI","file":"i.go","lineNumber":651}]}],"groupingHash":"custom grouping hash","metaData":{"custom tab":{"my key":"my value"}},"payloadVersion":"4","session":{"startedAt":"`
-const expLargePost = `,"severity":"info","severityReason":{"type":"unhandledError","attributes":{"framework":"gin"}},"unhandled":true,"user":{"id":"1234baerg134","name":"Kool Kidz on da bus","email":"typo@busgang.com"}}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.7.0"}}`
+const expLargePost = `,"severity":"info","severityReason":{"type":"unhandledError","attributes":{"framework":"gin"}},"unhandled":true,"user":{"id":"1234baerg134","name":"Kool Kidz on da bus","email":"typo@busgang.com"}}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"1.8.0"}}`
 
 func TestMarshalEmptyPayload(t *testing.T) {
 	sessionTracker = sessions.NewSessionTracker(&sessionTrackingConfig)


### PR DESCRIPTION
### Enhancements

* Support unwrapping the underlying causes from an error, including attached stack trace contents if available.

  Any reported error which implements the following interface:

  ```go
  type errorWithCause interface {
    Unwrap() error
  }
  ```

  will have the cause included as a previous error in the resulting event. The cause information will be available on the Bugsnag dashboard and is available for inspection in callbacks on the `errors.Error` object.

  ```go
  bugsnag.OnBeforeNotify(func(event *bugsnag.Event, config *bugsnag.Configuration) error {
    if event.Error.Cause != nil {
      fmt.Printf("This error was caused by %v", event.Error.Cause.Error())
    }
    return nil
  })
  ```