### PR TITLE
add integration test for unrecovered panic

### DIFF
--- a/features/fixtures/app/Dockerfile
+++ b/features/fixtures/app/Dockerfile
@@ -1,9 +1,7 @@
 ARG GO_VERSION
 FROM golang:${GO_VERSION}-alpine
 
-RUN apk update && \
-    apk upgrade && \
-    apk add git
+RUN apk update && apk upgrade && apk add git bash
 
 ENV GOPATH /app
 
@@ -15,3 +13,6 @@ RUN go get . ./sessions ./headers ./errors
 # Copy test scenarios
 COPY ./app /app/src/test
 WORKDIR /app/src/test
+
+RUN chmod +x run.sh
+CMD ["/app/src/test/run.sh"]

--- a/features/fixtures/app/main.go
+++ b/features/fixtures/app/main.go
@@ -45,11 +45,11 @@ func configureBasicBugsnag(testcase string) {
 	}
 
 	switch testcase {
-	case "endpoint legacy":
+	case "endpoint-legacy":
 		config.Endpoint = os.Getenv("BUGSNAG_ENDPOINT")
-	case "endpoint notify":
+	case "endpoint-notify":
 		config.Endpoints = bugsnag.Endpoints{Notify: os.Getenv("BUGSNAG_ENDPOINT")}
-	case "endpoint session":
+	case "endpoint-session":
 		config.Endpoints = bugsnag.Endpoints{Sessions: os.Getenv("BUGSNAG_ENDPOINT")}
 	default:
 		config.Endpoints = bugsnag.Endpoints{
@@ -75,9 +75,9 @@ func main() {
 	switch *test {
 	case "unhandled":
 		unhandledCrash()
-	case "handled", "endpoint legacy", "endpoint notify", "endpoint session":
+	case "handled", "endpoint-legacy", "endpoint-notify", "endpoint-session":
 		handledError()
-	case "handled with callback":
+	case "handled-with-callback":
 		handledCallbackError()
 	case "session":
 		session()
@@ -91,19 +91,19 @@ func main() {
 		filtered()
 	case "recover":
 		dontDie()
-	case "session and error":
+	case "session-and-error":
 		sessionAndError()
-	case "send and exit":
+	case "send-and-exit":
 		sendAndExit()
 	case "user":
 		user()
-	case "multiple handled":
+	case "multiple-handled":
 		multipleHandled()
-	case "multiple unhandled":
+	case "multiple-unhandled":
 		multipleUnhandled()
-	case "make unhandled with callback":
+	case "make-unhandled-with-callback":
 		handledToUnhandled()
-	case "nested error":
+	case "nested-error":
 		nestedHandledError()
 	default:
 		log.Println("Not a valid test flag: " + *test)

--- a/features/fixtures/app/run.sh
+++ b/features/fixtures/app/run.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# SIGTERM or SIGINT trapped (likely SIGTERM from docker), pass it onto app
+# process
+function _term_or_init {
+  kill -TERM "$APP_PID" 2>/dev/null
+  wait $APP_PID
+}
+
+# The bugsnag notifier monitor process needs at least 300ms, in order to ensure
+# that it can send its notify
+function _exit {
+  sleep 1
+}
+
+trap _term_or_init SIGTERM SIGINT
+trap _exit EXIT
+
+PROC="${@:1}"
+$PROC &
+
+# Wait on the app process to ensure that this script is able to trap the SIGTERM
+# signal
+APP_PID=$!
+wait $APP_PID

--- a/features/plain_features/endpoint.feature
+++ b/features/plain_features/endpoint.feature
@@ -6,16 +6,16 @@ Background:
   And I have built the service "app"
 
 Scenario: An error report is sent successfully using the legacy endpoint
-  When I run the go service "app" with the test case "endpoint legacy"
+  When I run the go service "app" with the test case "endpoint-legacy"
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
 
 Scenario: An error report is sent successfully using the notify endpoint only
-  When I run the go service "app" with the test case "endpoint notify"
+  When I run the go service "app" with the test case "endpoint-notify"
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
 
 Scenario: Configuring Bugsnag will panic if the sessions endpoint is configured without the notify endpoint
-  When I run the go service "app" with the test case "endpoint session"
+  When I run the go service "app" with the test case "endpoint-session"
   And I wait for 3 second
   Then I should receive no requests

--- a/features/plain_features/handled.feature
+++ b/features/plain_features/handled.feature
@@ -28,7 +28,7 @@ Scenario: A handled error sends a report with a custom name
   And the "file" of stack frame 0 equals "main.go"
 
 Scenario: Sending an event using a callback to modify report contents
-  When I run the go service "app" with the test case "handled with callback"
+  When I run the go service "app" with the test case "handled-with-callback"
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is false
@@ -41,7 +41,7 @@ Scenario: Sending an event using a callback to modify report contents
   And the "lineNumber" of stack frame 1 equals 0
 
 Scenario: Marking an error as unhandled in a callback
-  When I run the go service "app" with the test case "make unhandled with callback"
+  When I run the go service "app" with the test case "make-unhandled-with-callback"
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is true
@@ -52,7 +52,7 @@ Scenario: Marking an error as unhandled in a callback
   And stack frame 0 contains a local function spanning 255 to 258
 
 Scenario: Unwrapping the causes of a handled error
-  When I run the go service "app" with the test case "nested error"
+  When I run the go service "app" with the test case "nested-error"
   Then I wait to receive a request
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event "unhandled" is false

--- a/features/plain_features/multieventsession.feature
+++ b/features/plain_features/multieventsession.feature
@@ -7,7 +7,7 @@ Background:
   And I set environment variable "AUTO_CAPTURE_SESSIONS" to "false"
 
 Scenario: Handled errors know about previous reported handled errors
-  When I run the go service "app" with the test case "multiple handled"
+  When I run the go service "app" with the test case "multiple-handled"
   And I wait to receive 2 requests
   And the request 0 is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the request 1 is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
@@ -15,7 +15,7 @@ Scenario: Handled errors know about previous reported handled errors
   And the event handled sessions count equals 2 for request 1
 
 Scenario: Unhandled errors know about previous reported handled errors
-  When I run the go service "app" with the test case "multiple unhandled"
+  When I run the go service "app" with the test case "multiple-unhandled"
   And I wait to receive 2 requests
   And the request 0 is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the request 1 is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"

--- a/features/plain_features/panics.feature
+++ b/features/plain_features/panics.feature
@@ -1,0 +1,23 @@
+Feature: Panic handling
+
+    Background:
+      Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+      And I configure the bugsnag endpoint
+      And I have built the service "app"
+      And I set environment variable "AUTO_CAPTURE_SESSIONS" to "false"
+
+    Scenario: Capturing a panic
+      When I run the go service "app" with the test case "unhandled"
+      Then I wait to receive a request
+      And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+      And the event "unhandled" is true
+      And the event "severity" equals "error"
+      And the event "severityReason.type" equals "unhandledPanic"
+      And the exception "errorClass" equals "panic"
+      And the exception "message" is one of:
+        | interface conversion: interface is struct {}, not string      |
+        | interface conversion: interface {} is struct {}, not string   |
+      And the in-project frames of the stacktrace are:
+        | file    | method               |
+        | main.go | unhandledCrash.func1 |
+        | main.go | unhandledCrash       |

--- a/features/plain_features/sessioncontext.feature
+++ b/features/plain_features/sessioncontext.feature
@@ -6,7 +6,7 @@ Background:
   And I have built the service "app"
 
 Scenario: An error report contains a session count when part of a session
-  When I run the go service "app" with the test case "session and error"
+  When I run the go service "app" with the test case "session-and-error"
   Then I wait to receive 2 requests after the start up session
   And the request 0 is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the request 1 is a valid session report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"

--- a/features/plain_features/synchronous.feature
+++ b/features/plain_features/synchronous.feature
@@ -8,13 +8,13 @@ Background:
 
 Scenario: An error report is sent asynchrously but exits immediately so is not sent
   Given I set environment variable "SYNCHRONOUS" to "false"
-  When I run the go service "app" with the test case "send and exit"
+  When I run the go service "app" with the test case "send-and-exit"
   And I wait for 3 second
   Then I should receive no requests
 
 Scenario: An error report is report synchronously so it will send before exiting
   Given I set environment variable "SYNCHRONOUS" to "true"
-  When I run the go service "app" with the test case "send and exit"
+  When I run the go service "app" with the test case "send-and-exit"
   Then I wait to receive 1 requests
   And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
 


### PR DESCRIPTION
## Goal

Add regression test coverage for crucial component of the library, adding a scaffold for some improvements coming in this area.

## Changeset

Probably easiest to see each commit:

* The first to remove spaces was to make the new scripts run easier without dealing with adding escaping logic in a few places.
* The second adds a run script to the test environment so that when the process crashes, there is time for the remaining event to be sent. This script is similar to ones in production environments, where otherwise the process won't be able to be properly monitored (since in go crash info is only present in stdout/err and not passed to handlers).

The test case itself is simple with two variations in error message depending on the go version.