### PR TITLE
feat: capture 'fatal error' crashes as panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Support capturing "fatal error"-style panics from go, such as from concurrent
+  map read/writes, out of memory errors, and nil goroutines.
+
 ## 1.8.0 (2020-12-03)
 
 ### Enhancements

--- a/errors/error.go
+++ b/errors/error.go
@@ -154,8 +154,8 @@ func (err *Error) StackFrames() []StackFrame {
 
 // TypeName returns the type this error. e.g. *errors.stringError.
 func (err *Error) TypeName() string {
-	if _, ok := err.Err.(uncaughtPanic); ok {
-		return "panic"
+	if p, ok := err.Err.(uncaughtPanic); ok {
+		return p.typeName
 	}
 	if name := reflect.TypeOf(err.Err).String(); len(name) > 0 {
 		return name

--- a/errors/parse_panic_test.go
+++ b/errors/parse_panic_test.go
@@ -140,3 +140,66 @@ func TestParsePanic(t *testing.T) {
 		}
 	}
 }
+
+var concurrentMapReadWrite = `fatal error: concurrent map read and map write
+
+goroutine 1 [running]:
+runtime.throw(0x10766f5, 0x21)
+	/usr/local/Cellar/go/1.15.5/libexec/src/runtime/panic.go:1116 +0x72 fp=0xc00003a6c8 sp=0xc00003a698 pc=0x102d592
+runtime.mapaccess1_faststr(0x1066fc0, 0xc000060000, 0x10732e0, 0x1, 0xc000100088)
+	/usr/local/Cellar/go/1.15.5/libexec/src/runtime/map_faststr.go:21 +0x465 fp=0xc00003a738 sp=0xc00003a6c8 pc=0x100e9c5
+main.concurrentWrite()
+	/myapps/go/fatalerror/main.go:14 +0x7a fp=0xc00003a778 sp=0xc00003a738 pc=0x105d83a
+main.main()
+	/myapps/go/fatalerror/main.go:41 +0x25 fp=0xc00003a788 sp=0xc00003a778 pc=0x105d885
+runtime.main()
+	/usr/local/Cellar/go/1.15.5/libexec/src/runtime/proc.go:204 +0x209 fp=0xc00003a7e0 sp=0xc00003a788 pc=0x102fd49
+runtime.goexit()
+	/usr/local/Cellar/go/1.15.5/libexec/src/runtime/asm_amd64.s:1374 +0x1 fp=0xc00003a7e8 sp=0xc00003a7e0 pc=0x105a4a1
+
+goroutine 5 [runnable]:
+main.concurrentWrite.func1(0xc000060000)
+	/myapps/go/fatalerror/main.go:10 +0x4c
+created by main.concurrentWrite
+	/myapps/go/fatalerror/main.go:8 +0x4b
+`
+
+func TestParseFatalError(t *testing.T) {
+
+	Err, err := ParsePanic(concurrentMapReadWrite)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if Err.TypeName() != "fatal error" {
+		t.Errorf("Wrong type: %s", Err.TypeName())
+	}
+
+	if Err.Error() != "concurrent map read and map write" {
+		t.Errorf("Wrong message: '%s'", Err.Error())
+	}
+
+	if Err.StackFrames()[0].Func() != nil {
+		t.Errorf("Somehow managed to find a func...")
+	}
+
+	var result = []StackFrame{
+		StackFrame{File: "/usr/local/Cellar/go/1.15.5/libexec/src/runtime/panic.go", LineNumber: 1116, Name: "throw", Package: "runtime"},
+		StackFrame{File: "/usr/local/Cellar/go/1.15.5/libexec/src/runtime/map_faststr.go", LineNumber: 21, Name: "mapaccess1_faststr", Package: "runtime"},
+		StackFrame{File: "/myapps/go/fatalerror/main.go", LineNumber: 14, Name: "concurrentWrite", Package: "main"},
+		StackFrame{File: "/myapps/go/fatalerror/main.go", LineNumber: 41, Name: "main", Package: "main"},
+		StackFrame{File: "/usr/local/Cellar/go/1.15.5/libexec/src/runtime/proc.go", LineNumber: 204, Name: "main", Package: "runtime"},
+		StackFrame{File: "/usr/local/Cellar/go/1.15.5/libexec/src/runtime/asm_amd64.s", LineNumber: 1374, Name: "goexit", Package: "runtime"},
+	}
+
+	if !reflect.DeepEqual(Err.StackFrames(), result) {
+		t.Errorf("Wrong stack for concurrent write fatal error:")
+		for i, frame := range result {
+			t.Logf("[%d] %#v", i, frame)
+			if len(Err.StackFrames()) > i {
+				t.Logf("    %#v", Err.StackFrames()[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Goal

Support parsing "fatal error"-style panics from go, such as from concurrent map read/writes, out of memory errors, and nil goroutines.

## Design

In the event of an unrecoverable error, the go runtime invokes [`fatalpanic`](https://github.com/golang/go/blob/2517f4946b42b8deedb864c884f1b41311d45850/src/runtime/panic.go#L1185). These errors terminate the process with a message matching ["fatal error: [cause]"](https://github.com/golang/go/blob/2517f4946b42b8deedb864c884f1b41311d45850/src/runtime/panic.go#L1106). This changeset updates the parser to look for the "fatal error:" component to begin parsing the rest of the goroutine contents as a crash.

## Changeset

Updated the go process output parser to detect panics which begin with "fatal error". Some errors terminate the process without the more common "panic" header.

There will be a companion PR to panicwrap to actually capture these errors.

## Testing

* Added a new parser test from a concurrent read/write error
* There will be integration tests after merging down these changes and the related panicwrap change