### PR TITLE
Support configuring the library through environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Support configuring Bugsnag through environment variables
+
 ## 1.9.0 (2021-01-05)
 
 ### Enhancements

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -1,0 +1,81 @@
+Feature: Configure integration with environment variables
+
+    The library should be configurable using environment variables to support
+    single-line and reusable configuration
+
+    Background:
+        Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And I set environment variable "BUGSNAG_NOTIFY_ENDPOINT" to the notify endpoint
+        And I set environment variable "BUGSNAG_SESSIONS_ENDPOINT" to the sessions endpoint
+        And I have built the service "autoconfigure"
+
+    Scenario Outline: Adding content to handled events through env variables
+        Given I set environment variable "<variable>" to "<value>"
+        And I set environment variable "BUGSNAG_AUTO_CAPTURE_SESSIONS" to "0"
+        When I run the go service "autoconfigure" with the test case "<testcase>"
+        Then I wait to receive a request
+        And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And the event "<field>" equals "<value>"
+
+        Examples:
+            | testcase | variable                              | value           | field                         |
+            | panic    | BUGSNAG_APP_VERSION                   | 1.4.34          | app.version                   |
+            | panic    | BUGSNAG_APP_TYPE                      | mailer-daemon   | app.type                      |
+            | panic    | BUGSNAG_RELEASE_STAGE                 | beta1           | app.releaseStage              |
+            | panic    | BUGSNAG_HOSTNAME                      | dream-machine-2 | device.hostname               |
+
+            | handled  | BUGSNAG_APP_VERSION                   | 1.4.34          | app.version                   |
+            | handled  | BUGSNAG_APP_TYPE                      | mailer-daemon   | app.type                      |
+            | handled  | BUGSNAG_RELEASE_STAGE                 | beta1           | app.releaseStage              |
+            | handled  | BUGSNAG_HOSTNAME                      | dream-machine-2 | device.hostname               |
+
+    Scenario: Configuring project packages
+        Given I set environment variable "BUGSNAG_PROJECT_PACKAGES" to "main,test"
+        And I set environment variable "BUGSNAG_AUTO_CAPTURE_SESSIONS" to "0"
+        When I run the go service "autoconfigure" with the test case "panic"
+        Then I wait to receive a request
+        And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And the in-project frames of the stacktrace are:
+            | file     | method        | lineNumber |
+            | cases.go | explicitPanic | 22         |
+            | main.go  | main          | 11         |
+
+    Scenario: Configuring source root
+        Given I set environment variable "BUGSNAG_SOURCE_ROOT" to the app directory
+        And I set environment variable "BUGSNAG_AUTO_CAPTURE_SESSIONS" to "0"
+        And I run the go service "autoconfigure" with the test case "panic"
+        Then I wait to receive a request
+        And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And the in-project frames of the stacktrace are:
+            | file     | method        | lineNumber |
+            | cases.go | explicitPanic | 22         |
+            | main.go  | main          | 11         |
+
+    Scenario: Delivering events filtering through notify release stages
+        Given I set environment variable "BUGSNAG_NOTIFY_RELEASE_STAGES" to "prod,beta"
+        And I set environment variable "BUGSNAG_RELEASE_STAGE" to "beta"
+        And I set environment variable "BUGSNAG_AUTO_CAPTURE_SESSIONS" to "0"
+        And I run the go service "autoconfigure" with the test case "panic"
+        Then I wait to receive a request
+        And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
+    Scenario: Suppressing events through notify release stages
+        Given I set environment variable "BUGSNAG_NOTIFY_RELEASE_STAGES" to "prod,beta"
+        And I set environment variable "BUGSNAG_RELEASE_STAGE" to "dev"
+        And I set environment variable "BUGSNAG_AUTO_CAPTURE_SESSIONS" to "0"
+        And I run the go service "autoconfigure" with the test case "panic"
+        Then 0 requests were received
+
+    Scenario: Enabling synchronous event delivery
+        Given I set environment variable "BUGSNAG_SYNCHRONOUS" to "1"
+        And I set environment variable "BUGSNAG_AUTO_CAPTURE_SESSIONS" to "0"
+        When I run the go service "autoconfigure" with the test case "handled"
+        Then 1 request was received
+
+    Scenario: Filtering metadata
+        Given I set environment variable "BUGSNAG_PARAMS_FILTERS" to "tomato,pears"
+        And I set environment variable "BUGSNAG_AUTO_CAPTURE_SESSIONS" to "0"
+        When I run the go service "autoconfigure" with the test case "handled-metadata"
+        Then I wait to receive a request
+        And the event "metaData.fruit.Tomato" equals "[FILTERED]"
+        And the event "metaData.snacks.Carrot" equals "4"

--- a/features/fixtures/autoconfigure/Dockerfile
+++ b/features/fixtures/autoconfigure/Dockerfile
@@ -1,0 +1,18 @@
+ARG GO_VERSION
+FROM golang:${GO_VERSION}-alpine
+
+RUN apk update && apk upgrade && apk add git bash
+
+ENV GOPATH /app
+
+COPY testbuild /app/src/github.com/bugsnag/bugsnag-go
+WORKDIR /app/src/github.com/bugsnag/bugsnag-go
+
+RUN go get . ./sessions ./headers ./errors
+
+# Copy test scenarios
+COPY ./autoconfigure /app/src/test
+WORKDIR /app/src/test
+
+RUN chmod +x run.sh
+CMD ["/app/src/test/run.sh"]

--- a/features/fixtures/autoconfigure/cases.go
+++ b/features/fixtures/autoconfigure/cases.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/bugsnag/bugsnag-go/v2"
+)
+
+func explicitPanic() {
+	panic("PANIQ!")
+}
+
+func handledEvent() {
+	bugsnag.Notify(fmt.Errorf("gone awry!"))
+}
+
+func handledMetadata() {
+	bugsnag.OnBeforeNotify(func(event *bugsnag.Event, config *bugsnag.Configuration) error {
+		event.MetaData.Add("fruit", "Tomato", "beefsteak")
+		event.MetaData.Add("snacks", "Carrot", "4")
+		return nil
+	})
+	handledEvent()
+}

--- a/features/fixtures/autoconfigure/main.go
+++ b/features/fixtures/autoconfigure/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/bugsnag/bugsnag-go/v2"
+)
+
+var testcase = flag.String("test", "", "the error scenario to run")
+
+func main() {
+	bugsnag.Configure(bugsnag.Configuration{})
+
+	// Increase publish rate for testing
+	bugsnag.DefaultSessionPublishInterval = time.Millisecond * 50
+
+	flag.Parse()
+
+	switch *testcase {
+	case "panic":
+		explicitPanic()
+	case "handled":
+		handledEvent()
+	case "handled-metadata":
+		handledMetadata()
+	case "no-op":
+		// nothing to see here
+	default:
+		fmt.Printf("No test case found for '%s'\n", *testcase)
+	}
+	time.Sleep(time.Millisecond * 100) // time to send before termination
+}

--- a/features/fixtures/autoconfigure/run.sh
+++ b/features/fixtures/autoconfigure/run.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# SIGTERM or SIGINT trapped (likely SIGTERM from docker), pass it onto app
+# process
+function _term_or_init {
+  kill -TERM "$APP_PID" 2>/dev/null
+  wait $APP_PID
+}
+
+# The bugsnag notifier monitor process needs at least 300ms, in order to ensure
+# that it can send its notify
+function _exit {
+  sleep 1
+}
+
+trap _term_or_init SIGTERM SIGINT
+trap _exit EXIT
+
+PROC="${@:1}"
+$PROC &
+
+# Wait on the app process to ensure that this script is able to trap the SIGTERM
+# signal
+APP_PID=$!
+wait $APP_PID

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -21,6 +21,29 @@ services:
       - SERVER_PORT
     restart: "no"
 
+  autoconfigure:
+    build:
+      context: .
+      dockerfile: autoconfigure/Dockerfile
+      args:
+       - GO_VERSION
+    environment:
+      - BUGSNAG_API_KEY
+      - BUGSNAG_APP_TYPE
+      - BUGSNAG_APP_VERSION
+      - BUGSNAG_AUTO_CAPTURE_SESSIONS
+      - BUGSNAG_HOSTNAME
+      - BUGSNAG_NOTIFY_ENDPOINT
+      - BUGSNAG_NOTIFY_RELEASE_STAGES
+      - BUGSNAG_PARAMS_FILTERS
+      - BUGSNAG_PROJECT_PACKAGES
+      - BUGSNAG_RELEASE_STAGE
+      - BUGSNAG_SESSIONS_ENDPOINT
+      - BUGSNAG_SOURCE_ROOT
+      - BUGSNAG_SYNCHRONOUS
+    restart: "no"
+    command: go run .
+
   nethttp:
     build:
       context: .

--- a/features/steps/go_steps.rb
+++ b/features/steps/go_steps.rb
@@ -1,5 +1,19 @@
 require 'net/http'
 
+Given("I set environment variable {string} to the app directory") do |key|
+  step("I set environment variable \"#{key}\" to \"/app/src/test/\"")
+end
+
+Given("I set environment variable {string} to the notify endpoint") do |key|
+  step("I set environment variable \"#{key}\" to \"http://#{current_ip}:#{MOCK_API_PORT}\"")
+end
+
+Given("I set environment variable {string} to the sessions endpoint") do |key|
+  # they're the same picture dot gif
+  # split them out for the future endpoint splitting work
+  step("I set environment variable \"#{key}\" to \"http://#{current_ip}:#{MOCK_API_PORT}\"")
+end
+
 Then(/^the request(?: (\d+))? is a valid error report with api key "(.*)"$/) do |request_index, api_key|
   request_index ||= 0
   steps %Q{
@@ -30,7 +44,7 @@ Then(/^the number of sessions started equals (\d+) for request (\d+)$/) do |coun
 end
 
 When("I run the go service {string} with the test case {string}") do  |service, testcase|
-  run_service_with_command(service, "./run.sh go run main.go -test=\"#{testcase}\"")
+  run_service_with_command(service, "./run.sh go run . -test=\"#{testcase}\"")
 end
 
 Then(/^I wait to receive a request after the start up session$/) do
@@ -57,6 +71,11 @@ Then(/^I wait to receive (\d+) requests after the start up session?$/) do |reque
   end
   raise "Requests not received in 10s (received #{stored_requests.size})" unless received
   # Wait an extra second to ensure there are no further requests
+  sleep 1
+  assert_equal(request_count, stored_requests.size, "#{stored_requests.size} requests received")
+end
+
+Then(/^(\d+) requests? (?:was|were) received$/) do |request_count|
   sleep 1
   assert_equal(request_count, stored_requests.size, "#{stored_requests.size} requests received")
 end

--- a/v2/bugsnag.go
+++ b/v2/bugsnag.go
@@ -25,6 +25,7 @@ const VERSION = "1.9.0"
 
 var panicHandlerOnce sync.Once
 var sessionTrackerOnce sync.Once
+var readEnvConfigOnce sync.Once
 var middleware middlewareStack
 
 // Config is the configuration for the default bugsnag notifier.
@@ -43,6 +44,8 @@ var sessionTracker sessions.SessionTracker
 // is also responsible for installing the global panic handler, so it should be
 // called as early as possible in your initialization process.
 func Configure(config Configuration) {
+	// Load configuration from the environment, if any
+	readEnvConfigOnce.Do(Config.loadEnv)
 	Config.update(&config)
 	updateSessionConfig()
 	// Only do once in case the user overrides the default panichandler, and

--- a/v2/configuration.go
+++ b/v2/configuration.go
@@ -3,6 +3,7 @@ package bugsnag
 import (
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -261,4 +262,49 @@ func (config *Configuration) notifyInReleaseStage() bool {
 		}
 	}
 	return false
+}
+
+func (config *Configuration) loadEnv() {
+	envConfig := Configuration{}
+	if apiKey := os.Getenv("BUGSNAG_API_KEY"); apiKey != "" {
+		envConfig.APIKey = apiKey
+	}
+	if endpoint := os.Getenv("BUGSNAG_SESSIONS_ENDPOINT"); endpoint != "" {
+		envConfig.Endpoints.Sessions = endpoint
+	}
+	if endpoint := os.Getenv("BUGSNAG_NOTIFY_ENDPOINT"); endpoint != "" {
+		envConfig.Endpoints.Notify = endpoint
+	}
+	if stage := os.Getenv("BUGSNAG_RELEASE_STAGE"); stage != "" {
+		envConfig.ReleaseStage = stage
+	}
+	if appVersion := os.Getenv("BUGSNAG_APP_VERSION"); appVersion != "" {
+		envConfig.AppVersion = appVersion
+	}
+	if hostname := os.Getenv("BUGSNAG_HOSTNAME"); hostname != "" {
+		envConfig.Hostname = hostname
+	}
+	if sourceRoot := os.Getenv("BUGSNAG_SOURCE_ROOT"); sourceRoot != "" {
+		envConfig.SourceRoot = sourceRoot
+	}
+	if appType := os.Getenv("BUGSNAG_APP_TYPE"); appType != "" {
+		envConfig.AppType = appType
+	}
+	if stages := os.Getenv("BUGSNAG_NOTIFY_RELEASE_STAGES"); stages != "" {
+		envConfig.NotifyReleaseStages = strings.Split(stages, ",")
+	}
+	if packages := os.Getenv("BUGSNAG_PROJECT_PACKAGES"); packages != "" {
+		envConfig.ProjectPackages = strings.Split(packages, ",")
+	}
+	if synchronous := os.Getenv("BUGSNAG_SYNCHRONOUS"); synchronous != "" {
+		envConfig.Synchronous = synchronous == "1"
+	}
+	if autoSessions := os.Getenv("BUGSNAG_AUTO_CAPTURE_SESSIONS"); autoSessions != "" {
+		envConfig.AutoCaptureSessions = autoSessions == "1"
+	}
+	if filters := os.Getenv("BUGSNAG_PARAMS_FILTERS"); filters != "" {
+		envConfig.ParamsFilters = strings.Split(filters, ",")
+	}
+
+	config.update(&envConfig)
 }


### PR DESCRIPTION
## Goal

Read `BUGSNAG_*` environment variables and configure the library automatically.

## Design

* For string-based properties, variables are accepted as-is. For example, the value of `BUGSNAG_API_KEY`, if set, is applied to `Configuration.APIKey`.
* For slice of string properties, commas are supported as a delimiter. Set `BUGSNAG_PROJECT_PACKAGES` to `main,example.com/repo` to mark code from the `main` and `example.com/repo` packages as in-project.
* For boolean properties, variables are checked against the string value `1`, and, if not empty string, are set to true if equal or false if not.

## Testing

Added new integration tests for each supported variable