### PR TITLE
build: remove dependency on osext

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -4,8 +4,7 @@ go 1.15
 
 require (
 	github.com/bitly/go-simplejson v0.5.0
-	github.com/bugsnag/panicwrap v1.3.0
+	github.com/bugsnag/panicwrap v1.3.1
 	github.com/gofrs/uuid v4.0.0+incompatible
-	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/pkg/errors v0.9.1
 )

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,8 +1,5 @@
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
-github.com/bugsnag/panicwrap v1.3.0 h1:zJBEFv8WZJS+rDufHteJyZMXXzMBMiyv6UBtCoEochM=
-github.com/bugsnag/panicwrap v1.3.0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
+github.com/bugsnag/panicwrap v1.3.1 h1:pmuhHlhbUV4OOrGDvoiMjHSZzwRcL+I9cIzYKiW4lII=
+github.com/bugsnag/panicwrap v1.3.1/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
-github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/v2/panicwrap_test.go
+++ b/v2/panicwrap_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/bitly/go-simplejson"
 	"github.com/bugsnag/bugsnag-go/v2/sessions"
-	"github.com/kardianos/osext"
 )
 
 // Test the panic handler by launching a new process which runs the init()
@@ -85,7 +84,7 @@ func TestPanicHandlerUnhandledPanic(t *testing.T) {
 }
 
 func startPanickingProcess(t *testing.T, variant string, endpoint string) {
-	exePath, err := osext.Executable()
+	exePath, err := os.Executable()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Unneeded on go1.8+ (and the baseline for v2 is go1.11+)