### PR TITLE
Remove deprecated config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## TBD
 
+### Breaking Changes
+
+* Removed `Configuration.Endpoint`. Use `Configuration.Endpoints` instead. For
+  more info and an example, see the [Upgrading guide](./UPGRADING.md)
+
 ### Enhancements
 
 * Support configuring Bugsnag through environment variables

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,22 @@
+# Upgrading guide
+
+## v1 to v2
+
+The v2 release adds support for Go modules, removes web framework
+integrations from the main repository, and supports library configuration
+through environment variables. The following breaking changes occurred as a part
+of this release:
+
+### Removed `Configuration.Endpoint`
+
+The `Endpoint` configuration option was deprecated as a part of the v1.4.0
+release in November 2018. It was replaced with `Endpoints`, which includes
+options for configuring both event and session delivery.
+
+```diff+go
+- config.Endpoint = "https://notify.myserver.example.com"
++ config.Endpoints = {
++ 	Notify: "https://notify.myserver.example.com",
++ 	Sessions: "https://sessions.myserver.example.com"
++ }
+```

--- a/features/endpoint.feature
+++ b/features/endpoint.feature
@@ -5,11 +5,6 @@ Background:
   And I configure the bugsnag endpoint
   And I have built the service "app"
 
-Scenario: An error report is sent successfully using the legacy endpoint
-  When I run the go service "app" with the test case "endpoint-legacy"
-  Then I wait to receive a request
-  And the request is a valid error report with api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-
 Scenario: An error report is sent successfully using the notify endpoint only
   When I run the go service "app" with the test case "endpoint-notify"
   Then I wait to receive a request

--- a/features/fixtures/app/main.go
+++ b/features/fixtures/app/main.go
@@ -45,8 +45,6 @@ func configureBasicBugsnag(testcase string) {
 	}
 
 	switch testcase {
-	case "endpoint-legacy":
-		config.Endpoint = os.Getenv("BUGSNAG_ENDPOINT")
 	case "endpoint-notify":
 		config.Endpoints = bugsnag.Endpoints{Notify: os.Getenv("BUGSNAG_ENDPOINT")}
 	case "endpoint-session":

--- a/features/handled.feature
+++ b/features/handled.feature
@@ -36,7 +36,7 @@ Scenario: Sending an event using a callback to modify report contents
   And the event "severityReason.type" equals "userCallbackSetSeverity"
   And the event "context" equals "nonfatal.go:14"
   And the "file" of stack frame 0 equals "main.go"
-  And stack frame 0 contains a local function spanning 243 to 249
+  And stack frame 0 contains a local function spanning 241 to 247
   And the "file" of stack frame 1 equals ">insertion<"
   And the "lineNumber" of stack frame 1 equals 0
 
@@ -49,7 +49,7 @@ Scenario: Marking an error as unhandled in a callback
   And the event "severityReason.type" equals "userCallbackSetSeverity"
   And the event "severityReason.unhandledOverridden" is true
   And the "file" of stack frame 0 equals "main.go"
-  And stack frame 0 contains a local function spanning 255 to 258
+  And stack frame 0 contains a local function spanning 253 to 256
 
 Scenario: Unwrapping the causes of a handled error
   When I run the go service "app" with the test case "nested-error"
@@ -58,12 +58,12 @@ Scenario: Unwrapping the causes of a handled error
   And the event "unhandled" is false
   And the event "severity" equals "warning"
   And the event "exceptions.0.message" equals "terminate process"
-  And the "lineNumber" of stack frame 0 equals 293
+  And the "lineNumber" of stack frame 0 equals 291
   And the "file" of stack frame 0 equals "main.go"
   And the "method" of stack frame 0 equals "nestedHandledError"
   And the event "exceptions.1.message" equals "login failed"
   And the event "exceptions.1.stacktrace.0.file" equals "main.go"
-  And the event "exceptions.1.stacktrace.0.lineNumber" equals 313
+  And the event "exceptions.1.stacktrace.0.lineNumber" equals 311
   And the event "exceptions.2.message" equals "invalid token"
   And the event "exceptions.2.stacktrace.0.file" equals "main.go"
-  And the event "exceptions.2.stacktrace.0.lineNumber" equals 321
+  And the event "exceptions.2.stacktrace.0.lineNumber" equals 319

--- a/v2/configuration.go
+++ b/v2/configuration.go
@@ -20,11 +20,6 @@ type Configuration struct {
 	// find this by clicking Settings on https://bugsnag.com/.
 	APIKey string
 
-	// Deprecated: Use Endpoints (with an 's') instead.
-	// The Endpoint to notify about crashes. This defaults to
-	// "https://notify.bugsnag.com/", if you're using Bugsnag Enterprise then
-	// set it to your internal Bugsnag endpoint.
-	Endpoint string
 	// Endpoints define the HTTP endpoints that the notifier should notify
 	// about crashes and sessions. These default to notify.bugsnag.com for
 	// error reports and sessions.bugsnag.com for sessions.
@@ -155,7 +150,7 @@ func (config *Configuration) update(other *Configuration) *Configuration {
 	if other.AutoCaptureSessions != nil {
 		config.AutoCaptureSessions = other.AutoCaptureSessions
 	}
-	config.updateEndpoints(other.Endpoint, &other.Endpoints)
+	config.updateEndpoints(&other.Endpoints)
 	return config
 }
 
@@ -174,13 +169,7 @@ func (config *Configuration) IsAutoCaptureSessions() bool {
 	return false
 }
 
-func (config *Configuration) updateEndpoints(endpoint string, endpoints *Endpoints) {
-
-	if endpoint != "" {
-		config.Logger.Printf("WARNING: the 'Endpoint' Bugsnag configuration parameter is deprecated in favor of 'Endpoints'")
-		config.Endpoints.Notify = endpoint
-		config.Endpoints.Sessions = ""
-	}
+func (config *Configuration) updateEndpoints(endpoints *Endpoints) {
 	if endpoints.Notify != "" {
 		config.Endpoints.Notify = endpoints.Notify
 		if endpoints.Sessions == "" {

--- a/v2/configuration_test.go
+++ b/v2/configuration_test.go
@@ -230,27 +230,6 @@ func TestEndpointDeprecationWarning(t *testing.T) {
 		}, logger
 	}
 
-	t.Run("Setting Endpoint gives deprecation warning", func(st *testing.T) {
-		c, logger := setUp()
-		config := Configuration{Endpoint: "https://endpoint.whatever.com/"}
-		c.update(&config)
-		if got := logger.loggedMessages; len(got) != 1 {
-			st.Errorf("Expected exactly one logged message but got %d: %v", len(got), got)
-		}
-		got := logger.loggedMessages[0]
-		for _, exp := range []string{"WARNING", "Bugsnag", "Endpoint", "Endpoints", "deprecated"} {
-			if !strings.Contains(got, exp) {
-				st.Errorf("Expected logger message containing '%s' when configuring but got %s.", exp, got)
-			}
-		}
-		if got, exp := c.Endpoints.Notify, config.Endpoint; got != exp {
-			st.Errorf("Expected notify endpoint '%s' but got '%s'", exp, got)
-		}
-		if got, exp := c.Endpoints.Sessions, ""; got != exp {
-			st.Errorf("Expected sessions endpoint '%s' but got '%s'", exp, got)
-		}
-	})
-
 	t.Run("Setting Endpoints.Notify without setting Endpoints.Sessions gives session disabled warning", func(st *testing.T) {
 		c, logger := setUp()
 		config := Configuration{


### PR DESCRIPTION
`Endpoint` has been deprecated for some time, removing it as a part of the major release.