### PR TITLE
Rename constant to match platform idioms

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -41,3 +41,10 @@ updating each integration independently.
 - import "github.com/bugsnag/bugsnag-go/gin"
 + import "github.com/bugsnag/bugsnag-go-gin"
 ```
+
+### Renamed constants for platform consistency
+
+```diff+go
+- bugsnag.VERSION
++ bugsnag.Version
+```

--- a/v2/bugsnag.go
+++ b/v2/bugsnag.go
@@ -20,8 +20,8 @@ import (
 	_ "crypto/sha512"
 )
 
-// VERSION defines the version of this Bugsnag notifier
-const VERSION = "1.9.0"
+// Version defines the version of this Bugsnag notifier
+const Version = "1.9.0"
 
 var panicHandlerOnce sync.Once
 var sessionTrackerOnce sync.Once
@@ -265,7 +265,7 @@ func updateSessionConfig() {
 		APIKey:              Config.APIKey,
 		AutoCaptureSessions: Config.AutoCaptureSessions,
 		Endpoint:            Config.Endpoints.Sessions,
-		Version:             VERSION,
+		Version:             Version,
 		PublishInterval:     DefaultSessionPublishInterval,
 		Transport:           Config.Transport,
 		ReleaseStage:        Config.ReleaseStage,

--- a/v2/bugsnag_test.go
+++ b/v2/bugsnag_test.go
@@ -558,7 +558,7 @@ func assertPayload(t *testing.T, report *simplejson.Json, exp eventJSON) {
 		{prop: "API Key", exp: testAPIKey, got: getString(report, "apiKey")},
 
 		{prop: "notifier name", exp: "Bugsnag Go", got: getString(report, "notifier.name")},
-		{prop: "notifier version", exp: VERSION, got: getString(report, "notifier.version")},
+		{prop: "notifier version", exp: Version, got: getString(report, "notifier.version")},
 		{prop: "notifier url", exp: "https://github.com/bugsnag/bugsnag-go", got: getString(report, "notifier.url")},
 
 		{prop: "exception message", exp: expException.Message, got: getString(exception, "message")},

--- a/v2/payload.go
+++ b/v2/payload.go
@@ -91,7 +91,7 @@ func (p *payload) MarshalJSON() ([]byte, error) {
 		Notifier: notifierJSON{
 			Name:    "Bugsnag Go",
 			URL:     "https://github.com/bugsnag/bugsnag-go",
-			Version: VERSION,
+			Version: Version,
 		},
 	})
 }

--- a/v2/payload_test.go
+++ b/v2/payload_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/bugsnag/bugsnag-go/v2/sessions"
 )
 
-const expSmall = `{"apiKey":"","events":[{"app":{"releaseStage":""},"device":{"osName":"%s","runtimeVersions":{"go":"%s"}},"exceptions":[{"errorClass":"","message":"","stacktrace":null}],"metaData":{},"payloadVersion":"4","severity":"","unhandled":false}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"` + VERSION + `"}}`
+const expSmall = `{"apiKey":"","events":[{"app":{"releaseStage":""},"device":{"osName":"%s","runtimeVersions":{"go":"%s"}},"exceptions":[{"errorClass":"","message":"","stacktrace":null}],"metaData":{},"payloadVersion":"4","severity":"","unhandled":false}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"` + Version + `"}}`
 
 // The large payload has a timestamp in it which makes it awkward to assert against.
 // Instead, assert that the timestamp property exist, along with the rest of the expected payload
 const expLargePre = `{"apiKey":"166f5ad3590596f9aa8d601ea89af845","events":[{"app":{"releaseStage":"mega-production","type":"gin","version":"1.5.3"},"context":"/api/v2/albums","device":{"hostname":"super.duper.site","osName":"%s","runtimeVersions":{"go":"%s"}},"exceptions":[{"errorClass":"error class","message":"error message goes here","stacktrace":[{"method":"doA","file":"a.go","lineNumber":65},{"method":"fetchB","file":"b.go","lineNumber":99,"inProject":true},{"method":"incrementI","file":"i.go","lineNumber":651}]}],"groupingHash":"custom grouping hash","metaData":{"custom tab":{"my key":"my value"}},"payloadVersion":"4","session":{"startedAt":"`
-const expLargePost = `,"severity":"info","severityReason":{"type":"unhandledError","attributes":{"framework":"gin"}},"unhandled":true,"user":{"id":"1234baerg134","name":"Kool Kidz on da bus","email":"typo@busgang.com"}}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"` + VERSION + `"}}`
+const expLargePost = `,"severity":"info","severityReason":{"type":"unhandledError","attributes":{"framework":"gin"}},"unhandled":true,"user":{"id":"1234baerg134","name":"Kool Kidz on da bus","email":"typo@busgang.com"}}],"notifier":{"name":"Bugsnag Go","url":"https://github.com/bugsnag/bugsnag-go","version":"` + Version + `"}}`
 
 func TestMarshalEmptyPayload(t *testing.T) {
 	sessionTracker = sessions.NewSessionTracker(&sessionTrackingConfig)

--- a/v2/sessions/integration_test.go
+++ b/v2/sessions/integration_test.go
@@ -62,7 +62,7 @@ func TestStartSession(t *testing.T) {
 		}{
 			{prop: "notifier.name", exp: "Bugsnag Go"},
 			{prop: "notifier.url", exp: "https://github.com/bugsnag/bugsnag-go"},
-			{prop: "notifier.version", exp: bugsnag.VERSION},
+			{prop: "notifier.version", exp: bugsnag.Version},
 			{prop: "app.releaseStage", exp: "production"},
 			{prop: "app.version", exp: ""},
 			{prop: "device.osName", exp: runtime.GOOS},


### PR DESCRIPTION
## Goal

Replaces `VERSION` with `Version` to be better aligned with Go naming conventions.