### PR TITLE
fix(config): ensure correct path separator used on windows

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -5,13 +5,14 @@ on: [ push, pull_request ]
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
     defaults:
       run:
         working-directory: 'go/src/github.com/bugsnag/bugsnag-go' # relative to $GITHUB_WORKSPACE
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu, windows]
         go-version: ['1.11', '1.12', '1.13', '1.14', '1.15']
         major-version: ['v2']
 
@@ -19,17 +20,17 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: 'go/src/github.com/bugsnag/bugsnag-go' # relative to $GITHUB_WORKSPACE
-    - name: setup go ${{ matrix.go-version }}
+    - name: set GOPATH
+      if: matrix.os == 'ubuntu'
       run: |
-        curl --silent --location --output gimme https://github.com/travis-ci/gimme/raw/v1.5.4/gimme
-        chmod +x ./gimme
-        eval "$(./gimme ${{ matrix.go-version }})"
-        echo "GOOS=" >> $GITHUB_ENV
-        echo "GOARCH=" >> $GITHUB_ENV
-        echo "GOROOT=$GOROOT" >> $GITHUB_ENV
-        echo "PATH=$PATH" >> $GITHUB_ENV
-        echo "GIMME_ENV=$GIMME_ENV" >> $GITHUB_ENV
-        echo "GOPATH=$GITHUB_WORKSPACE/go" >> $GITHUB_ENV
+        bash -c 'echo "GOPATH=$GITHUB_WORKSPACE/go" >> $GITHUB_ENV'
+    - name: set GOPATH
+      if: matrix.os == 'windows'
+      run: |
+        bash -c 'echo "GOPATH=$GITHUB_WORKSPACE\\\\go" >> $GITHUB_ENV'
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
     - name: install dependencies
       run: go get -v -d ./${{ matrix.major-version }}/...
     - name: run tests
@@ -40,11 +41,13 @@ jobs:
       run: go vet ./${{ matrix.major-version }}/...
 
     - name: install integration dependencies
+      if: matrix.os == 'ubuntu'
       run: |
         sudo apt-get install docker-compose
         sudo gem install bundler
         bundle install
     - name: maze tests
+      if: matrix.os == 'ubuntu'
       env:
         GO_VERSION: ${{ matrix.go-version }}
       run: bundle exec bugsnag-maze-runner --color --format progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Fix `GOPATH`, `SourceRoot` and project package path stripping from stack
+  traces on Windows by using the correct path separators.
+
 ## 2.0.0 (2021-01-18)
 
 The v2 release adds support for Go modules, removes web framework

--- a/v2/panicwrap_test.go
+++ b/v2/panicwrap_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -60,6 +61,10 @@ func TestPanicHandlerHandledPanic(t *testing.T) {
 // Test the panic handler by launching a new process which runs the init()
 // method in this file and causing an unhandled panic
 func TestPanicHandlerUnhandledPanic(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("not compatible with windows builds")
+		return
+	}
 	ts, reports := setup()
 	defer ts.Close()
 

--- a/v2/sessions/integration_test.go
+++ b/v2/sessions/integration_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 const testAPIKey = "166f5ad3590596f9aa8d601ea89af845"
-const testPublishInterval = time.Millisecond * 20
+const testPublishInterval = time.Millisecond * 200
 const sessionsCount = 50000
 
 func init() {
@@ -41,6 +41,10 @@ func getIndex(j *simplejson.Json, path string, index int) *simplejson.Json {
 // Spins up a session server and checks that for every call to
 // bugsnag.StartSession() a session is being recorded.
 func TestStartSession(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("not compatible with windows builds")
+		return
+	}
 	sessionsStarted := 0
 	mutex := sync.Mutex{}
 


### PR DESCRIPTION
## Goal

Fix a bug on windows where build/run paths are not correctly stripped depending on which path separators are used. Go itself always returns file paths using `/` as the separator, though the `GOPATH` environment variable (and/or `GOROOT()`) may use `\` depending on a system's settings.

## Changeset

* Added a check when a configuration is updated to swap path separators on windows if needed

## Testing

* Updated the existing unit suite to run on windows on CI
* Tested the change manually:

Before:

<img width="635" alt="ugly unstripped path" src="https://user-images.githubusercontent.com/333454/105878893-70450900-5ff9-11eb-812b-8f91a1cce37d.png">

After:

<img width="509" alt="much nicer after the change" src="https://user-images.githubusercontent.com/333454/105878924-7c30cb00-5ff9-11eb-9cd7-8fa5b67d8625.png">
