### PR TITLE
Support appending metadata through environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## TBD
 
+### Enhancements
+
+* Support appending metadata through environment variables prefixed with
+  `BUGSNAG_METADATA_`
+
 ### Bug fixes
 
 * Fix `GOPATH`, `SourceRoot` and project package path stripping from stack

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -23,11 +23,19 @@ Feature: Configure integration with environment variables
             | panic    | BUGSNAG_APP_TYPE                      | mailer-daemon   | app.type                      |
             | panic    | BUGSNAG_RELEASE_STAGE                 | beta1           | app.releaseStage              |
             | panic    | BUGSNAG_HOSTNAME                      | dream-machine-2 | device.hostname               |
+            | panic    | BUGSNAG_METADATA_device_instance      | kube2-33-A      | metaData.device.instance      |
+            | panic    | BUGSNAG_METADATA_framework_version    | v3.1.0          | metaData.framework.version    |
+            | panic    | BUGSNAG_METADATA_device_runtime_level | 1C              | metaData.device.runtime_level |
+            | panic    | BUGSNAG_METADATA_Carrot               | orange          | metaData.custom.Carrot        |
 
             | handled  | BUGSNAG_APP_VERSION                   | 1.4.34          | app.version                   |
             | handled  | BUGSNAG_APP_TYPE                      | mailer-daemon   | app.type                      |
             | handled  | BUGSNAG_RELEASE_STAGE                 | beta1           | app.releaseStage              |
             | handled  | BUGSNAG_HOSTNAME                      | dream-machine-2 | device.hostname               |
+            | handled  | BUGSNAG_METADATA_device_instance      | kube2-33-A      | metaData.device.instance      |
+            | handled  | BUGSNAG_METADATA_framework_version    | v3.1.0          | metaData.framework.version    |
+            | handled  | BUGSNAG_METADATA_device_runtime_level | 1C              | metaData.device.runtime_level |
+            | handled  | BUGSNAG_METADATA_Carrot               | orange          | metaData.custom.Carrot        |
 
     Scenario: Configuring project packages
         Given I set environment variable "BUGSNAG_PROJECT_PACKAGES" to "main,test"

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -42,6 +42,12 @@ services:
       - BUGSNAG_SESSIONS_ENDPOINT
       - BUGSNAG_SOURCE_ROOT
       - BUGSNAG_SYNCHRONOUS
+      - BUGSNAG_METADATA_Carrot
+      - BUGSNAG_METADATA_device_instance
+      - BUGSNAG_METADATA_device_runtime_level
+      - BUGSNAG_METADATA_framework_version
+      - BUGSNAG_METADATA_fruit_Tomato
+      - BUGSNAG_METADATA_snacks_Carrot
     restart: "no"
     command: go run .
 

--- a/v2/configuration.go
+++ b/v2/configuration.go
@@ -319,5 +319,14 @@ func (config *Configuration) loadEnv() {
 		envConfig.ParamsFilters = strings.Split(filters, ",")
 	}
 
+	metadata := loadEnvMetadata(os.Environ())
+	OnBeforeNotify(func(event *Event, config *Configuration) error {
+		for _, m := range metadata {
+			event.MetaData.Add(m.tab, m.key, m.value)
+		}
+
+		return nil
+	})
+
 	config.update(&envConfig)
 }

--- a/v2/env_metadata.go
+++ b/v2/env_metadata.go
@@ -1,0 +1,46 @@
+package bugsnag
+
+import (
+	"fmt"
+	"strings"
+)
+
+const metadataPrefix string = "BUGSNAG_METADATA_"
+const metadataPrefixLen int = len(metadataPrefix)
+const metadataDefaultTab string = "custom"
+
+type envMetadata struct {
+	tab   string
+	key   string
+	value string
+}
+
+func loadEnvMetadata(environ []string) []envMetadata {
+	metadata := make([]envMetadata, 0)
+	for _, value := range environ {
+		key, value, err := parseEnvironmentPair(value)
+		if err != nil {
+			continue
+		}
+		if keypath, err := parseMetadataKeypath(key); err == nil {
+			tab, key := splitTabKeyValues(keypath)
+			metadata = append(metadata, envMetadata{tab, key, value})
+		}
+	}
+	return metadata
+}
+
+func splitTabKeyValues(keypath string) (string, string) {
+	key_components := strings.SplitN(keypath, "_", 2)
+	if len(key_components) > 1 {
+		return key_components[0], key_components[1]
+	}
+	return metadataDefaultTab, keypath
+}
+
+func parseMetadataKeypath(key string) (string, error) {
+	if strings.HasPrefix(key, metadataPrefix) && len(key) > metadataPrefixLen {
+		return strings.TrimPrefix(key, metadataPrefix), nil
+	}
+	return "", fmt.Errorf("No metadata prefix found")
+}

--- a/v2/env_metadata_test.go
+++ b/v2/env_metadata_test.go
@@ -1,0 +1,65 @@
+package bugsnag
+
+import "testing"
+
+func TestParseMetadataKeypath(t *testing.T) {
+	type output struct {
+		keypath string
+		err     string
+	}
+	cases := map[string]output{
+		"":                                {"", "No metadata prefix found"},
+		"BUGSNAG_METADATA_":               {"", "No metadata prefix found"},
+		"BUGSNAG_METADATA_key":            {"key", ""},
+		"BUGSNAG_METADATA_device_foo":     {"device_foo", ""},
+		"BUGSNAG_METADATA_device_foo_two": {"device_foo_two", ""},
+	}
+
+	for input, expected := range cases {
+		keypath, err := parseMetadataKeypath(input)
+		if len(expected.err) > 0 && (err == nil || err.Error() != expected.err) {
+			t.Errorf("expected error with message '%s', got '%v'", expected.err, err)
+		}
+		if expected.keypath != keypath {
+			t.Errorf("expected keypath '%s', got '%s'", expected.keypath, keypath)
+		}
+	}
+}
+
+func TestLoadEnvMetadata(t *testing.T) {
+	cases := map[string]envMetadata{
+		"":                                     {"", "", ""},
+		"BUGSNAG_METADATA_Orange=tomato_paste": {"custom", "Orange", "tomato_paste"},
+		"BUGSNAG_METADATA_true_orange=tomato_paste":             {"true", "orange", "tomato_paste"},
+		"BUGSNAG_METADATA_color_Orange=tomato_paste":            {"color", "Orange", "tomato_paste"},
+		"BUGSNAG_METADATA_color_Orange_hue=tomato_paste":        {"color", "Orange_hue", "tomato_paste"},
+		"BUGSNAG_METADATA_crayonColor_Magenta=tomato_paste":     {"crayonColor", "Magenta", "tomato_paste"},
+		"BUGSNAG_METADATA_crayonColor_Magenta_hue=tomato_paste": {"crayonColor", "Magenta_hue", "tomato_paste"},
+	}
+
+	for input, expected := range cases {
+		metadata := loadEnvMetadata([]string{input})
+
+		if len(expected.tab) == 0 {
+			for _, m := range metadata {
+				t.Errorf("erroneously added a value for '%s' to tab '%s':'%s'", input, m.tab, m.key)
+			}
+		} else {
+			if len(metadata) != 1 {
+				t.Fatalf("wrong number of metadata elements: %d %v", len(metadata), metadata)
+			}
+			m := metadata[0]
+			if m.tab != expected.tab {
+				t.Errorf("wrong tab '%s'", expected.tab)
+				continue
+			}
+			if m.key != expected.key {
+				t.Errorf("wrong key '%s'", expected.key)
+				continue
+			}
+			if m.value != expected.value {
+				t.Errorf("incorrect value added to keypath: '%s'", m.value)
+			}
+		}
+	}
+}

--- a/v2/environment.go
+++ b/v2/environment.go
@@ -1,0 +1,14 @@
+package bugsnag
+
+import (
+	"fmt"
+	"strings"
+)
+
+func parseEnvironmentPair(pair string) (string, string, error) {
+	components := strings.SplitN(pair, "=", 2)
+	if len(components) < 2 {
+		return "", "", fmt.Errorf("Not a '='-delimited key pair")
+	}
+	return components[0], components[1], nil
+}

--- a/v2/environment_test.go
+++ b/v2/environment_test.go
@@ -1,0 +1,29 @@
+package bugsnag
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParsePairs(t *testing.T) {
+	type output struct {
+		key, value string
+		err error
+	}
+
+	cases := map[string]output{
+		"":{"", "", fmt.Errorf("Not a '='-delimited key pair")},
+		"key=value":{"key", "value", nil},
+		"key=value=bar":{"key", "value=bar", nil},
+		"something":{"", "", fmt.Errorf("Not a '='-delimited key pair")},
+	}
+	for input, expected := range cases {
+		key, value, err := parseEnvironmentPair(input)
+		if expected.err != nil && (err == nil || err.Error() != expected.err.Error()) {
+			t.Errorf("expected error '%v', got '%v'", expected.err, err)
+		}
+		if key != expected.key || value != expected.value {
+			t.Errorf("expected pair '%s'='%s', got '%s'='%s'", expected.key, expected.value, key, value)
+		}
+	}
+}


### PR DESCRIPTION
## Goal 

Support "no code" metadata collection by automatically collecting content from the environment with a bugsnag prefix.

🗒️ Largely reviewed previously as a part of #155 (https://github.com/bugsnag/bugsnag-go/pull/155#discussion_r555643621, https://github.com/bugsnag/bugsnag-go/pull/155#discussion_r558238333), with suggested adjustments

## Design

The environment variable name after the prefix is expected to be the tab and key name, optionally delimited by an underscore.

Examples:

```bash
BUGSNAG_METADATA_device_KubePod="carrot-delivery-service-beta1 reg3"
BUGSNAG_METADATA_device_deployment_area=region5_1
BUGSNAG_METADATA_carrier=proof
```

```json
{
	"metaData": {
		"device": {
			"KubePod": "carrot-delivery-service-beta1 reg3",
			"deployment_area": "region5_1"
		},
		"custom": { "carrier": "proof" }
	}
}
```


## Changeset

* `Configuration.loadEnv()`: Automatically adds a callback which adds any matching metadata to all events

## Testing

* Added new integration tests to cover these cases