### PR TITLE
release v2.1.0

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -5,13 +5,14 @@ on: [ push, pull_request ]
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
     defaults:
       run:
         working-directory: 'go/src/github.com/bugsnag/bugsnag-go' # relative to $GITHUB_WORKSPACE
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu, windows]
         go-version: ['1.11', '1.12', '1.13', '1.14', '1.15']
         major-version: ['v2']
 
@@ -19,17 +20,17 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: 'go/src/github.com/bugsnag/bugsnag-go' # relative to $GITHUB_WORKSPACE
-    - name: setup go ${{ matrix.go-version }}
+    - name: set GOPATH
+      if: matrix.os == 'ubuntu'
       run: |
-        curl --silent --location --output gimme https://github.com/travis-ci/gimme/raw/v1.5.4/gimme
-        chmod +x ./gimme
-        eval "$(./gimme ${{ matrix.go-version }})"
-        echo "GOOS=" >> $GITHUB_ENV
-        echo "GOARCH=" >> $GITHUB_ENV
-        echo "GOROOT=$GOROOT" >> $GITHUB_ENV
-        echo "PATH=$PATH" >> $GITHUB_ENV
-        echo "GIMME_ENV=$GIMME_ENV" >> $GITHUB_ENV
-        echo "GOPATH=$GITHUB_WORKSPACE/go" >> $GITHUB_ENV
+        bash -c 'echo "GOPATH=$GITHUB_WORKSPACE/go" >> $GITHUB_ENV'
+    - name: set GOPATH
+      if: matrix.os == 'windows'
+      run: |
+        bash -c 'echo "GOPATH=$GITHUB_WORKSPACE\\\\go" >> $GITHUB_ENV'
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
     - name: install dependencies
       run: go get -v -d ./${{ matrix.major-version }}/...
     - name: run tests
@@ -40,11 +41,13 @@ jobs:
       run: go vet ./${{ matrix.major-version }}/...
 
     - name: install integration dependencies
+      if: matrix.os == 'ubuntu'
       run: |
         sudo apt-get install docker-compose
         sudo gem install bundler
         bundle install
     - name: maze tests
+      if: matrix.os == 'ubuntu'
       env:
         GO_VERSION: ${{ matrix.go-version }}
       run: bundle exec bugsnag-maze-runner --color --format progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Fix `GOPATH`, `SourceRoot` and project package path stripping from stack
+  traces on Windows by using the correct path separators.
+
 ## 2.0.0 (2021-01-18)
 
 The v2 release adds support for Go modules, removes web framework

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## 2.1.0 (2021-01-27)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## TBD
 
+### Enhancements
+
+* Support appending metadata through environment variables prefixed with
+  `BUGSNAG_METADATA_`
+
 ### Bug fixes
 
 * Fix `GOPATH`, `SourceRoot` and project package path stripping from stack

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -23,11 +23,19 @@ Feature: Configure integration with environment variables
             | panic    | BUGSNAG_APP_TYPE                      | mailer-daemon   | app.type                      |
             | panic    | BUGSNAG_RELEASE_STAGE                 | beta1           | app.releaseStage              |
             | panic    | BUGSNAG_HOSTNAME                      | dream-machine-2 | device.hostname               |
+            | panic    | BUGSNAG_METADATA_device_instance      | kube2-33-A      | metaData.device.instance      |
+            | panic    | BUGSNAG_METADATA_framework_version    | v3.1.0          | metaData.framework.version    |
+            | panic    | BUGSNAG_METADATA_device_runtime_level | 1C              | metaData.device.runtime_level |
+            | panic    | BUGSNAG_METADATA_Carrot               | orange          | metaData.custom.Carrot        |
 
             | handled  | BUGSNAG_APP_VERSION                   | 1.4.34          | app.version                   |
             | handled  | BUGSNAG_APP_TYPE                      | mailer-daemon   | app.type                      |
             | handled  | BUGSNAG_RELEASE_STAGE                 | beta1           | app.releaseStage              |
             | handled  | BUGSNAG_HOSTNAME                      | dream-machine-2 | device.hostname               |
+            | handled  | BUGSNAG_METADATA_device_instance      | kube2-33-A      | metaData.device.instance      |
+            | handled  | BUGSNAG_METADATA_framework_version    | v3.1.0          | metaData.framework.version    |
+            | handled  | BUGSNAG_METADATA_device_runtime_level | 1C              | metaData.device.runtime_level |
+            | handled  | BUGSNAG_METADATA_Carrot               | orange          | metaData.custom.Carrot        |
 
     Scenario: Configuring project packages
         Given I set environment variable "BUGSNAG_PROJECT_PACKAGES" to "main,test"

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -42,6 +42,12 @@ services:
       - BUGSNAG_SESSIONS_ENDPOINT
       - BUGSNAG_SOURCE_ROOT
       - BUGSNAG_SYNCHRONOUS
+      - BUGSNAG_METADATA_Carrot
+      - BUGSNAG_METADATA_device_instance
+      - BUGSNAG_METADATA_device_runtime_level
+      - BUGSNAG_METADATA_framework_version
+      - BUGSNAG_METADATA_fruit_Tomato
+      - BUGSNAG_METADATA_snacks_Carrot
     restart: "no"
     command: go run .
 

--- a/v2/bugsnag.go
+++ b/v2/bugsnag.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Version defines the version of this Bugsnag notifier
-const Version = "2.0.0"
+const Version = "2.1.0"
 
 var panicHandlerOnce sync.Once
 var sessionTrackerOnce sync.Once

--- a/v2/configuration.go
+++ b/v2/configuration.go
@@ -319,5 +319,14 @@ func (config *Configuration) loadEnv() {
 		envConfig.ParamsFilters = strings.Split(filters, ",")
 	}
 
+	metadata := loadEnvMetadata(os.Environ())
+	OnBeforeNotify(func(event *Event, config *Configuration) error {
+		for _, m := range metadata {
+			event.MetaData.Add(m.tab, m.key, m.value)
+		}
+
+		return nil
+	})
+
 	config.update(&envConfig)
 }

--- a/v2/env_metadata.go
+++ b/v2/env_metadata.go
@@ -1,0 +1,46 @@
+package bugsnag
+
+import (
+	"fmt"
+	"strings"
+)
+
+const metadataPrefix string = "BUGSNAG_METADATA_"
+const metadataPrefixLen int = len(metadataPrefix)
+const metadataDefaultTab string = "custom"
+
+type envMetadata struct {
+	tab   string
+	key   string
+	value string
+}
+
+func loadEnvMetadata(environ []string) []envMetadata {
+	metadata := make([]envMetadata, 0)
+	for _, value := range environ {
+		key, value, err := parseEnvironmentPair(value)
+		if err != nil {
+			continue
+		}
+		if keypath, err := parseMetadataKeypath(key); err == nil {
+			tab, key := splitTabKeyValues(keypath)
+			metadata = append(metadata, envMetadata{tab, key, value})
+		}
+	}
+	return metadata
+}
+
+func splitTabKeyValues(keypath string) (string, string) {
+	key_components := strings.SplitN(keypath, "_", 2)
+	if len(key_components) > 1 {
+		return key_components[0], key_components[1]
+	}
+	return metadataDefaultTab, keypath
+}
+
+func parseMetadataKeypath(key string) (string, error) {
+	if strings.HasPrefix(key, metadataPrefix) && len(key) > metadataPrefixLen {
+		return strings.TrimPrefix(key, metadataPrefix), nil
+	}
+	return "", fmt.Errorf("No metadata prefix found")
+}

--- a/v2/env_metadata_test.go
+++ b/v2/env_metadata_test.go
@@ -1,0 +1,65 @@
+package bugsnag
+
+import "testing"
+
+func TestParseMetadataKeypath(t *testing.T) {
+	type output struct {
+		keypath string
+		err     string
+	}
+	cases := map[string]output{
+		"":                                {"", "No metadata prefix found"},
+		"BUGSNAG_METADATA_":               {"", "No metadata prefix found"},
+		"BUGSNAG_METADATA_key":            {"key", ""},
+		"BUGSNAG_METADATA_device_foo":     {"device_foo", ""},
+		"BUGSNAG_METADATA_device_foo_two": {"device_foo_two", ""},
+	}
+
+	for input, expected := range cases {
+		keypath, err := parseMetadataKeypath(input)
+		if len(expected.err) > 0 && (err == nil || err.Error() != expected.err) {
+			t.Errorf("expected error with message '%s', got '%v'", expected.err, err)
+		}
+		if expected.keypath != keypath {
+			t.Errorf("expected keypath '%s', got '%s'", expected.keypath, keypath)
+		}
+	}
+}
+
+func TestLoadEnvMetadata(t *testing.T) {
+	cases := map[string]envMetadata{
+		"":                                     {"", "", ""},
+		"BUGSNAG_METADATA_Orange=tomato_paste": {"custom", "Orange", "tomato_paste"},
+		"BUGSNAG_METADATA_true_orange=tomato_paste":             {"true", "orange", "tomato_paste"},
+		"BUGSNAG_METADATA_color_Orange=tomato_paste":            {"color", "Orange", "tomato_paste"},
+		"BUGSNAG_METADATA_color_Orange_hue=tomato_paste":        {"color", "Orange_hue", "tomato_paste"},
+		"BUGSNAG_METADATA_crayonColor_Magenta=tomato_paste":     {"crayonColor", "Magenta", "tomato_paste"},
+		"BUGSNAG_METADATA_crayonColor_Magenta_hue=tomato_paste": {"crayonColor", "Magenta_hue", "tomato_paste"},
+	}
+
+	for input, expected := range cases {
+		metadata := loadEnvMetadata([]string{input})
+
+		if len(expected.tab) == 0 {
+			for _, m := range metadata {
+				t.Errorf("erroneously added a value for '%s' to tab '%s':'%s'", input, m.tab, m.key)
+			}
+		} else {
+			if len(metadata) != 1 {
+				t.Fatalf("wrong number of metadata elements: %d %v", len(metadata), metadata)
+			}
+			m := metadata[0]
+			if m.tab != expected.tab {
+				t.Errorf("wrong tab '%s'", expected.tab)
+				continue
+			}
+			if m.key != expected.key {
+				t.Errorf("wrong key '%s'", expected.key)
+				continue
+			}
+			if m.value != expected.value {
+				t.Errorf("incorrect value added to keypath: '%s'", m.value)
+			}
+		}
+	}
+}

--- a/v2/environment.go
+++ b/v2/environment.go
@@ -1,0 +1,14 @@
+package bugsnag
+
+import (
+	"fmt"
+	"strings"
+)
+
+func parseEnvironmentPair(pair string) (string, string, error) {
+	components := strings.SplitN(pair, "=", 2)
+	if len(components) < 2 {
+		return "", "", fmt.Errorf("Not a '='-delimited key pair")
+	}
+	return components[0], components[1], nil
+}

--- a/v2/environment_test.go
+++ b/v2/environment_test.go
@@ -1,0 +1,29 @@
+package bugsnag
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParsePairs(t *testing.T) {
+	type output struct {
+		key, value string
+		err error
+	}
+
+	cases := map[string]output{
+		"":{"", "", fmt.Errorf("Not a '='-delimited key pair")},
+		"key=value":{"key", "value", nil},
+		"key=value=bar":{"key", "value=bar", nil},
+		"something":{"", "", fmt.Errorf("Not a '='-delimited key pair")},
+	}
+	for input, expected := range cases {
+		key, value, err := parseEnvironmentPair(input)
+		if expected.err != nil && (err == nil || err.Error() != expected.err.Error()) {
+			t.Errorf("expected error '%v', got '%v'", expected.err, err)
+		}
+		if key != expected.key || value != expected.value {
+			t.Errorf("expected pair '%s'='%s', got '%s'='%s'", expected.key, expected.value, key, value)
+		}
+	}
+}

--- a/v2/panicwrap_test.go
+++ b/v2/panicwrap_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -60,6 +61,10 @@ func TestPanicHandlerHandledPanic(t *testing.T) {
 // Test the panic handler by launching a new process which runs the init()
 // method in this file and causing an unhandled panic
 func TestPanicHandlerUnhandledPanic(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("not compatible with windows builds")
+		return
+	}
 	ts, reports := setup()
 	defer ts.Close()
 

--- a/v2/sessions/integration_test.go
+++ b/v2/sessions/integration_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 const testAPIKey = "166f5ad3590596f9aa8d601ea89af845"
-const testPublishInterval = time.Millisecond * 20
+const testPublishInterval = time.Millisecond * 200
 const sessionsCount = 50000
 
 func init() {
@@ -41,6 +41,10 @@ func getIndex(j *simplejson.Json, path string, index int) *simplejson.Json {
 // Spins up a session server and checks that for every call to
 // bugsnag.StartSession() a session is being recorded.
 func TestStartSession(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("not compatible with windows builds")
+		return
+	}
 	sessionsStarted := 0
 	mutex := sync.Mutex{}
 


### PR DESCRIPTION
### Enhancements

* Support appending metadata through environment variables prefixed with
  `BUGSNAG_METADATA_`

### Bug fixes

* Fix `GOPATH`, `SourceRoot` and project package path stripping from stack
  traces on Windows by using the correct path separators.