### PR TITLE
docs(templates): fix the issue report & PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,13 +19,13 @@ A clear and concise description of what the bug is.
 4. See error
 
 ### Environment
-* Bugsnag version:
+* Bugsnag Go version:
 * Go version:
 * Integration framework version:
     * Martini:
     * Negroni:
     * net/http:
-    * Ravel:
+    * Revel:
     * Other:
 
 <!--

--- a/.github/support.md
+++ b/.github/support.md
@@ -9,7 +9,7 @@ When contacting support, please include as much information as necessary, includ
 - steps to reproduce
 - expected/actual behaviour 
 
-* Bugsnag version:
+* Bugsnag Go version:
 * Go version:
 * Integration framework version:
     * Martini:


### PR DESCRIPTION
## Goal

Bringing templates inline with our base config, to match other Go repos & fix typo. I have left Integration frameworks in the issue report template in case users raise issue in this repo rather than the specific framework repos