### PR TITLE
increase sleep to prevent failed tests

### DIFF
--- a/sessions/integration_test.go
+++ b/sessions/integration_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 const testAPIKey = "166f5ad3590596f9aa8d601ea89af845"
-const testPublishInterval = time.Millisecond * 20
+const testPublishInterval = time.Millisecond * 200
 const sessionsCount = 50000
 
 func init() {


### PR DESCRIPTION
## Goal

Stop failed ubuntu autopkgtests

## Design

Use the timeout from v2

## Changeset

increase the sleep duration

## Testing

tested in ubuntu autopkgtest environment using existing tests.


These tests were failing in the Ubuntu autopkgtest environment. We are not on version 2 yet, so this change is relevant to Ubuntu.