### PR TITLE
Update CI to run without legacy module config

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -8,21 +8,17 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     defaults:
       run:
-        working-directory: 'go/src/github.com/bugsnag/bugsnag-go' # relative to $GITHUB_WORKSPACE
+        working-directory: 'go/src/github.com/bugsnag/bugsnag-go/v2' # relative to $GITHUB_WORKSPACE
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu, windows]
         go-version: ['1.11', '1.12', '1.13', '1.14', '1.15', '1.16']
-        major-version: ['v2']
 
     steps:
     - uses: actions/checkout@v2
       with:
         path: 'go/src/github.com/bugsnag/bugsnag-go' # relative to $GITHUB_WORKSPACE
-    - name: enable legacy module support
-      run: |
-        bash -c 'echo "GO111MODULE=auto" >> $GITHUB_ENV'
     - name: set GOPATH
       if: matrix.os == 'ubuntu'
       run: |
@@ -35,13 +31,13 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - name: install dependencies
-      run: go get -v -d ./${{ matrix.major-version }}/...
+      run: go get -v -d ./...
     - name: run tests
-      run: go test ./${{ matrix.major-version }}/...
+      run: go test ./...
     - name: vet package
       # go1.12 vet shows spurious 'unknown identifier' issues
       if: matrix.go-version != '1.12'
-      run: go vet ./${{ matrix.major-version }}/...
+      run: go vet ./...
 
     - name: install integration dependencies
       if: matrix.os == 'ubuntu'
@@ -50,6 +46,7 @@ jobs:
         sudo gem install bundler
         bundle install
     - name: maze tests
+      working-directory: go/src/github.com/bugsnag/bugsnag-go # relative to $GITHUB_WORKSPACE
       if: matrix.os == 'ubuntu'
       env:
         GO_VERSION: ${{ matrix.go-version }}

--- a/features/fixtures/app/Dockerfile
+++ b/features/fixtures/app/Dockerfile
@@ -4,16 +4,23 @@ FROM golang:${GO_VERSION}-alpine
 RUN apk update && apk upgrade && apk add git bash
 
 ENV GOPATH /app
-ENV GO111MODULE auto
 
 COPY testbuild /app/src/github.com/bugsnag/bugsnag-go
-WORKDIR /app/src/github.com/bugsnag/bugsnag-go
+WORKDIR /app/src/github.com/bugsnag/bugsnag-go/v2
 
-RUN go get . ./sessions ./headers ./errors
+RUN go get ./...
 
 # Copy test scenarios
 COPY ./app /app/src/test
 WORKDIR /app/src/test
+
+# Ensure subsequent steps are re-run if the GO_VERSION variable changes
+ARG GO_VERSION
+# Create app module - avoid locking bugsnag dep by not checking it in
+# Skip on old versions of Go which pre-date modules
+RUN if [[ $GO_VERSION != '1.11' && $GO_VERSION != '1.12' ]]; then \
+        go mod init && go mod tidy; \
+    fi
 
 RUN chmod +x run.sh
 CMD ["/app/src/test/run.sh"]

--- a/features/fixtures/autoconfigure/Dockerfile
+++ b/features/fixtures/autoconfigure/Dockerfile
@@ -4,16 +4,24 @@ FROM golang:${GO_VERSION}-alpine
 RUN apk update && apk upgrade && apk add git bash
 
 ENV GOPATH /app
-ENV GO111MODULE auto
 
 COPY testbuild /app/src/github.com/bugsnag/bugsnag-go
-WORKDIR /app/src/github.com/bugsnag/bugsnag-go
+WORKDIR /app/src/github.com/bugsnag/bugsnag-go/v2
 
-RUN go get . ./sessions ./headers ./errors
+# Get bugsnag dependencies
+RUN go get ./...
 
 # Copy test scenarios
 COPY ./autoconfigure /app/src/test
 WORKDIR /app/src/test
+
+# Ensure subsequent steps are re-run if the GO_VERSION variable changes
+ARG GO_VERSION
+# Create app module - avoid locking bugsnag dep by not checking it in
+# Skip on old versions of Go which pre-date modules
+RUN if [[ $GO_VERSION != '1.11' && $GO_VERSION != '1.12' ]]; then \
+        go mod init && go mod tidy; \
+    fi
 
 RUN chmod +x run.sh
 CMD ["/app/src/test/run.sh"]

--- a/features/fixtures/net_http/Dockerfile
+++ b/features/fixtures/net_http/Dockerfile
@@ -6,13 +6,21 @@ RUN apk update && \
     apk add git
 
 ENV GOPATH /app
-ENV GO111MODULE auto
 
 COPY testbuild /app/src/github.com/bugsnag/bugsnag-go
-WORKDIR /app/src/github.com/bugsnag/bugsnag-go
+WORKDIR /app/src/github.com/bugsnag/bugsnag-go/v2
 
-RUN go get -v -d . ./sessions ./headers ./errors
+# Get bugsnag dependencies
+RUN go get ./...
 
 # Copy test scenarios
 COPY ./net_http /app/src/test
 WORKDIR /app/src/test
+
+# Ensure subsequent steps are re-run if the GO_VERSION variable changes
+ARG GO_VERSION
+# Create app module - avoid locking bugsnag dep by not checking it in
+# Skip on old versions of Go which pre-date modules
+RUN if [[ $GO_VERSION != '1.11' && $GO_VERSION != '1.12' ]]; then \
+        go mod init && go mod tidy; \
+    fi

--- a/features/handled.feature
+++ b/features/handled.feature
@@ -13,7 +13,7 @@ Scenario: A handled error sends a report
   And the event "unhandled" is false
   And the event "severity" equals "warning"
   And the event "severityReason.type" equals "handledError"
-  And the exception "errorClass" ends with "s.PathError"
+  And the exception is a PathError for request 0
   And the "file" of stack frame 0 equals "main.go"
 
 Scenario: A handled error sends a report with a custom name

--- a/features/net-http/handled.feature
+++ b/features/net-http/handled.feature
@@ -16,7 +16,7 @@ Scenario: A handled error sends a report
   And the event "unhandled" is false for request 0
   And the event "severity" equals "warning" for request 0
   And the event "severityReason.type" equals "handledError" for request 0
-  And the exception "errorClass" ends with "s.PathError" for request 0
+  And the exception is a PathError for request 0
   And the "file" of stack frame 0 equals "main.go" for request 0
 
 Scenario: A handled error sends a report with a custom name

--- a/features/steps/go_steps.rb
+++ b/features/steps/go_steps.rb
@@ -23,6 +23,16 @@ Then(/^the request(?: (\d+))? is a valid error report with api key "(.*)"$/) do 
   }
 end
 
+Then(/^the exception is a PathError for request (\d+)$/) do |request_index|
+  body = find_request(request_index)[:body]
+  error_class = body["events"][0]["exceptions"][0]["errorClass"]
+  if ['1.11', '1.12', '1.13', '1.14', '1.15'].include? ENV['GO_VERSION']
+    assert_equal(error_class, '*os.PathError')
+  else
+    assert_equal(error_class, '*fs.PathError')
+  end
+end
+
 Then(/^the request(?: (\d+))? is a valid session report with api key "(.*)"$/) do |request_index, api_key|
   request_index ||= 0
   steps %Q{

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -8,7 +8,7 @@ FileUtils.rm_rf(testBuildFolder)
 Dir.mkdir testBuildFolder
 
 # Copy the existing dir
-`find . -name '*.go' \
+`find . -name '*.go' -o -name 'go.sum' -o -name 'go.mod' \
         -not -path "./examples/*" \
         -not -path "./testutil/*" \
         -not -path "./v2/testutil/*" \


### PR DESCRIPTION
## Goal

The existing setup is dependent on `GO111MODULE=auto`, which will cease to work in [go1.17](https://blog.golang.org/go116-module-changes).

This change instead builds within the module-aware directories and adds mod files to test apps during the run.

Tidied up a test case along the way.