### PR TITLE
Middleware creates a new Request which clears context

### DIFF
--- a/bugsnag.go
+++ b/bugsnag.go
@@ -166,17 +166,15 @@ func Handler(h http.Handler, rawData ...interface{}) http.Handler {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		request := r
-
 		// Record a session if auto notify session is enabled
 		ctx := r.Context()
 		if Config.IsAutoCaptureSessions() {
 			ctx = StartSession(ctx)
 		}
-		ctx = AttachRequestData(ctx, request)
-		request = r.WithContext(ctx)
-		defer notifier.AutoNotify(ctx, request)
-		h.ServeHTTP(w, request)
+		ctx = AttachRequestData(ctx, r)
+		*r = *r.WithContext(ctx)
+		defer notifier.AutoNotify(ctx, r)
+		h.ServeHTTP(w, r)
 	})
 }
 


### PR DESCRIPTION
## Goal
I was finding that when multiple middlewares are chained together the context/request was being cleared by the bugsnag middleware. 

## Design

This changes the middleware handler so it doesn't allocate a new request object but instead updates the old request object with the new one. This preserves the context for other middlewares in the chain. 

## Testing

- Working on updating tests, just want to make sure this approach is correct (I'm new to Go)