### PR TITLE
Release v2.1.2

### DIFF
--- a/.github/workflows/license-audit.yml
+++ b/.github/workflows/license-audit.yml
@@ -1,0 +1,36 @@
+name: Audit bugsnag-go dependency licenses
+
+on: [push, pull_request]
+
+jobs:
+  license-audit:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 'go/src/github.com/bugsnag/bugsnag-go/v2'
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: 'go/src/github.com/bugsnag/bugsnag-go' # relative to $GITHUB_WORKSPACE
+
+    - name: set GOPATH
+      run: |
+        bash -c 'echo "GOPATH=$GITHUB_WORKSPACE/go" >> $GITHUB_ENV'
+
+    - name: Fetch decisions.yml
+      run: curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/global.yml -o decisions.yml
+
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.16'
+
+    - name: install dependencies
+      run: go get -v -d ./...
+
+    - name: Run License Finder
+      run: >
+        docker run -v $PWD:/scan licensefinder/license_finder /bin/bash -lc "
+          cd /scan &&
+          license_finder --decisions-file decisions.yml --enabled-package-managers=gomodules
+        "

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD (TBD)
+## 2.1.2 (2021-08-24)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD (TBD)
+
+### Enhancements
+
+* Update panicwrap dependency to v1.3.4 which fixes build support for linux & darwin arm64.
+
 ## 2.1.1 (2021-04-19)
 
 ### Enhancements

--- a/v2/bugsnag.go
+++ b/v2/bugsnag.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Version defines the version of this Bugsnag notifier
-const Version = "2.1.1"
+const Version = "2.1.2"
 
 var panicHandlerOnce sync.Once
 var sessionTrackerOnce sync.Once

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/bitly/go-simplejson v0.5.0
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
-	github.com/bugsnag/panicwrap v1.3.2
+	github.com/bugsnag/panicwrap v1.3.4
 	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/kr/pretty v0.2.1 // indirect

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -4,6 +4,8 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4Yn
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bugsnag/panicwrap v1.3.2 h1:pNcbtPtH4Y6VwK+oZVNV/2H6Hh3jOL0ZNVFZEfd/eA4=
 github.com/bugsnag/panicwrap v1.3.2/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/bugsnag/panicwrap v1.3.4 h1:A6sXFtDGsgU/4BLf5JT0o5uYg3EeKgGx3Sfs+/uk3pU=
+github.com/bugsnag/panicwrap v1.3.4/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -2,8 +2,6 @@ github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkN
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
-github.com/bugsnag/panicwrap v1.3.2 h1:pNcbtPtH4Y6VwK+oZVNV/2H6Hh3jOL0ZNVFZEfd/eA4=
-github.com/bugsnag/panicwrap v1.3.2/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/bugsnag/panicwrap v1.3.4 h1:A6sXFtDGsgU/4BLf5JT0o5uYg3EeKgGx3Sfs+/uk3pU=
 github.com/bugsnag/panicwrap v1.3.4/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=


### PR DESCRIPTION
## Goal

Update `bugsnag-go` to include changes from `next` branch.

## Changeset

* Update panicwrap dependency to v1.3.4 which fixes build support for linux & darwin arm64.
* Push licence auditor workflow changes from `next` branch.

## Testing

New version of `panicwrap` release was tested separately in https://github.com/bugsnag/panicwrap/releases/tag/v1.3.4