### PR TITLE
Allows to disable logging

### DIFF
--- a/v2/configuration.go
+++ b/v2/configuration.go
@@ -87,6 +87,8 @@ type Configuration struct {
 	// and you can disable this feature by passing an empty: func() {}
 	PanicHandler func()
 
+	// If enabled, logs will be disabled.
+	DisableLogging bool
 	// The logger that Bugsnag should log to. Uses the same defaults as go's
 	// builtin logging package. bugsnag-go logs whenever it notifies Bugsnag
 	// of an error, and when any error occurs inside the library itself.
@@ -252,6 +254,9 @@ func (config *Configuration) stripProjectPackages(file string) string {
 }
 
 func (config *Configuration) logf(fmt string, args ...interface{}) {
+	if config.DisableLogging {
+		return
+	}
 	if config != nil && config.Logger != nil {
 		config.Logger.Printf(fmt, args...)
 	} else {


### PR DESCRIPTION
## Goal

In my opinion, a library shouldn't make logs mandatory. 

Here's an issue that I faced. In my context, we have some services logging some errors. If an error is also sent to Bugsnag, because of [this line](https://github.com/bugsnag/bugsnag-go/blob/facdc95679f54775b44b3c634645aa2b0d981896/v2/report_publisher.go#L12), the error is logged twice. I propose that we allow clients to disable logging and handle error/success the way they want.

## Design

Add a configuration boolean.

## Changeset

The configuration boolean + a check in the `logf` method. Note that the change is backward compatible.

## Testing

N/A