### PR TITLE
refactor: use google uuid package

### DIFF
--- a/report.go
+++ b/report.go
@@ -3,7 +3,7 @@ package bugsnag
 import (
 	"github.com/bugsnag/bugsnag-go/device"
 	"github.com/bugsnag/bugsnag-go/sessions"
-	uuid "github.com/gofrs/uuid"
+	uuid "github.com/google/uuid"
 )
 
 type reportJSON struct {

--- a/sessions/publisher_test.go
+++ b/sessions/publisher_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	simplejson "github.com/bitly/go-simplejson"
-	uuid "github.com/gofrs/uuid"
+	uuid "github.com/google/uuid"
 )
 
 const (
@@ -225,11 +225,10 @@ func makeHeavyConfig() *SessionTrackingConfiguration {
 
 func makeSessions() ([]*Session, string) {
 	earliestTime := time.Now().Add(-6 * time.Minute)
-	genUUID := func() uuid.UUID { sessionID, _ := uuid.NewV4(); return sessionID }
 	return []*Session{
-		{StartedAt: earliestTime, ID: genUUID()},
-		{StartedAt: earliestTime.Add(2 * time.Minute), ID: genUUID()},
-		{StartedAt: earliestTime.Add(4 * time.Minute), ID: genUUID()},
+		{StartedAt: earliestTime, ID: uuid.New()},
+		{StartedAt: earliestTime.Add(2 * time.Minute), ID: uuid.New()},
+		{StartedAt: earliestTime.Add(4 * time.Minute), ID: uuid.New()},
 	}, earliestTime.UTC().Format(time.RFC3339)
 }
 

--- a/sessions/session.go
+++ b/sessions/session.go
@@ -3,7 +3,7 @@ package sessions
 import (
 	"time"
 
-	uuid "github.com/gofrs/uuid"
+	uuid "github.com/google/uuid"
 )
 
 // EventCounts register how many handled/unhandled events have happened for
@@ -21,10 +21,9 @@ type Session struct {
 }
 
 func newSession() *Session {
-	sessionID, _ := uuid.NewV4()
 	return &Session{
 		StartedAt:   time.Now(),
-		ID:          sessionID,
+		ID:          uuid.New(),
 		EventCounts: &EventCounts{},
 	}
 }

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bitly/go-simplejson v0.5.0
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/bugsnag/panicwrap v1.3.4
-	github.com/gofrs/uuid v4.0.0+incompatible
+	github.com/google/uuid v1.3.0
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/pkg/errors v0.9.1

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -4,8 +4,8 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4Yn
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bugsnag/panicwrap v1.3.4 h1:A6sXFtDGsgU/4BLf5JT0o5uYg3EeKgGx3Sfs+/uk3pU=
 github.com/bugsnag/panicwrap v1.3.4/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
-github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=

--- a/v2/report.go
+++ b/v2/report.go
@@ -3,7 +3,7 @@ package bugsnag
 import (
 	"github.com/bugsnag/bugsnag-go/v2/device"
 	"github.com/bugsnag/bugsnag-go/v2/sessions"
-	uuid "github.com/gofrs/uuid"
+	uuid "github.com/google/uuid"
 )
 
 type reportJSON struct {

--- a/v2/sessions/publisher_test.go
+++ b/v2/sessions/publisher_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	simplejson "github.com/bitly/go-simplejson"
-	uuid "github.com/gofrs/uuid"
+	uuid "github.com/google/uuid"
 )
 
 const (
@@ -219,11 +219,10 @@ func makeHeavyConfig() *SessionTrackingConfiguration {
 
 func makeSessions() ([]*Session, string) {
 	earliestTime := time.Now().Add(-6 * time.Minute)
-	genUUID := func() uuid.UUID { sessionID, _ := uuid.NewV4(); return sessionID }
 	return []*Session{
-		{StartedAt: earliestTime, ID: genUUID()},
-		{StartedAt: earliestTime.Add(2 * time.Minute), ID: genUUID()},
-		{StartedAt: earliestTime.Add(4 * time.Minute), ID: genUUID()},
+		{StartedAt: earliestTime, ID: uuid.New()},
+		{StartedAt: earliestTime.Add(2 * time.Minute), ID: uuid.New()},
+		{StartedAt: earliestTime.Add(4 * time.Minute), ID: uuid.New()},
 	}, earliestTime.UTC().Format(time.RFC3339)
 }
 

--- a/v2/sessions/session.go
+++ b/v2/sessions/session.go
@@ -3,7 +3,7 @@ package sessions
 import (
 	"time"
 
-	uuid "github.com/gofrs/uuid"
+	uuid "github.com/google/uuid"
 )
 
 // EventCounts register how many handled/unhandled events have happened for
@@ -21,10 +21,9 @@ type Session struct {
 }
 
 func newSession() *Session {
-	sessionID, _ := uuid.NewV4()
 	return &Session{
 		StartedAt:   time.Now(),
-		ID:          sessionID,
+		ID:          uuid.New(),
 		EventCounts: &EventCounts{},
 	}
 }


### PR DESCRIPTION
Replaces the gofrs uuid package as it broke support for old versions of go in a recent commit and has no mechanism for version control

## Testing

All behavior should be preserved, and go 1.11 and 1.12 tests pass again