### PR TITLE
Stop trimming everything before "main.go" on main packages

### DIFF
--- a/event.go
+++ b/event.go
@@ -198,7 +198,7 @@ func generateStacktrace(err *errors.Error, config *Configuration) []StackFrame {
 		inProject := config.isProjectPackage(frame.Package)
 
 		// remove $GOROOT and $GOHOME from other frames
-		if idx := strings.Index(file, frame.Package); idx > -1 {
+		if idx := strings.Index(file, frame.Package); idx > -1 && frame.Package != "main" {
 			file = file[idx:]
 		}
 		if inProject {


### PR DESCRIPTION
## Goal
No matter how I configure `SourceRoot` and `ProjectPackages`, any stack trace with a main package with a file containing "main" will be trimmed of its prefix, valid or not.
We should not do that, and let SourceRoot and ProjectPackages do that.

For example, if I have multiple main files, it can be confusing knowing which one is responsible when bugsnag shows all of them as `main.go`.

Another example, if I have a main file called `my_main_file.go`, it will show up in Bugsnag as just `main_file.go`, with the `my_` stripped off, which is clearly wrong.

I would expect that in bugsnag it would show up as something like `cmd/export-service/my_main_file.go`

## Design
Skip trimming everything in front of the word "main"

## Changeset
See file diff

## Testing
All automated tests pass.
Manual testing works as well, with the desired result.
