### PR TITLE
export Sanitizer and handle time, errors, stringers

### DIFF
--- a/v2/metadata.go
+++ b/v2/metadata.go
@@ -97,9 +97,8 @@ func (s Sanitizer) Sanitize(data interface{}) interface{} {
 		// This also covers time.Duration
 		return data.String()
 
-	case encoding.TextUnmarshaler:
-		var b []byte
-		if err := data.UnmarshalText(b); err == nil {
+	case encoding.TextMarshaler:
+		if b, err := data.MarshalText(); err == nil {
 			return string(b)
 		}
 	}

--- a/v2/metadata_test.go
+++ b/v2/metadata_test.go
@@ -1,8 +1,10 @@
 package bugsnag
 
 import (
+	stderrors "errors"
 	"reflect"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/bugsnag/bugsnag-go/v2/errors"
@@ -24,6 +26,12 @@ type _account struct {
 type _broken struct {
 	Me   *_broken
 	Data string
+}
+
+type _textMarshaller struct{}
+
+func (_textMarshaller) MarshalText() ([]byte, error) {
+	return []byte("marshalled text"), nil
 }
 
 var account = _account{}
@@ -123,6 +131,10 @@ func TestMetaDataSanitize(t *testing.T) {
 			"unsafe":   unsafe.Pointer(broken.Me),
 			"string":   "string",
 			"password": "secret",
+			"error":    stderrors.New("some error"),
+			"time":     time.Date(2023, 12, 5, 23, 59, 59, 123456789, time.UTC),
+			"duration": 105567462 * time.Millisecond,
+			"text":     _textMarshaller{},
 			"array": []hash{{
 				"creditcard": "1234567812345678",
 				"broken":     broken,
@@ -144,6 +156,10 @@ func TestMetaDataSanitize(t *testing.T) {
 			"unsafe":   "[unsafe.Pointer]",
 			"func":     "[func()]",
 			"password": "[FILTERED]",
+			"error":    "some error",
+			"time":     "2023-12-05T23:59:59.123456789Z",
+			"duration": "29h19m27.462s",
+			"text":     "marshalled text",
 			"array": []interface{}{map[string]interface{}{
 				"creditcard": "[FILTERED]",
 				"broken": map[string]interface{}{

--- a/v2/metadata_test.go
+++ b/v2/metadata_test.go
@@ -185,7 +185,7 @@ func TestSanitizerSanitize(t *testing.T) {
 		{nilPointer, "<nil>"},
 		{nilInterface, "<nil>"},
 	} {
-		s := &sanitizer{}
+		s := &Sanitizer{}
 		gotValue := s.Sanitize(tc.input)
 
 		if got, want := gotValue, tc.want; got != want {


### PR DESCRIPTION
## Goal
Right now, the only way to convert arbitrary `any` to something bugsnag can show well, is to use the `MetaData.AddStruct` method.
Except it has 3 problems:
* It ideally wants a struct
* At no point are the filters set correctly
* errors, time.Time, time.Duration, and lots of other things just show up as an empty `{}` in bugsnag

## Design
This problem can be solved by exporting Sanitizer, and adding some special handling for well known types.

## Changeset
See diff

## Testing
Add tests pass, and I am using this locally
