### PR TITLE
Updated test matrix to latest go versions.

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows]
-        go-version: ['1.11', '1.12', '1.13', '1.14', '1.15', '1.16']
+        go-version: ['1.11', '1.12', '1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22']
 
     steps:
     - uses: actions/checkout@v2

--- a/features/fixtures/app/Dockerfile
+++ b/features/fixtures/app/Dockerfile
@@ -8,14 +8,22 @@ ENV GOPATH /app
 COPY testbuild /app/src/github.com/bugsnag/bugsnag-go
 WORKDIR /app/src/github.com/bugsnag/bugsnag-go/v2
 
-RUN go get ./...
+# Ensure subsequent steps are re-run if the GO_VERSION variable changes
+ARG GO_VERSION
+
+# Get bugsnag dependencies using a conditional call to run go get or go install based on the go version
+RUN if [[ $(echo -e "1.11\n$GO_VERSION\n1.16" | sort -V | head -2 | tail -1) == "$GO_VERSION" ]]; then \
+        echo "Version is between 1.11 and 1.16, running go get"; \
+        go get ./...; \
+    else \
+        echo "Version is greater than 1.16, running go install"; \
+        go install ./...; \
+    fi
 
 # Copy test scenarios
 COPY ./app /app/src/test
 WORKDIR /app/src/test
 
-# Ensure subsequent steps are re-run if the GO_VERSION variable changes
-ARG GO_VERSION
 # Create app module - avoid locking bugsnag dep by not checking it in
 # Skip on old versions of Go which pre-date modules
 RUN if [[ $GO_VERSION != '1.11' && $GO_VERSION != '1.12' ]]; then \

--- a/features/fixtures/app/main.go
+++ b/features/fixtures/app/main.go
@@ -130,7 +130,7 @@ func multipleUnhandled() {
 	defer notifier.AutoNotify(ctx)
 	panic("oops")
 }
-
+//go:noinline
 func unhandledCrash() {
 	// Invalid type assertion, will panic
 	func(a interface{}) string {

--- a/features/fixtures/autoconfigure/Dockerfile
+++ b/features/fixtures/autoconfigure/Dockerfile
@@ -8,15 +8,22 @@ ENV GOPATH /app
 COPY testbuild /app/src/github.com/bugsnag/bugsnag-go
 WORKDIR /app/src/github.com/bugsnag/bugsnag-go/v2
 
-# Get bugsnag dependencies
-RUN go get ./...
+# Ensure subsequent steps are re-run if the GO_VERSION variable changes
+ARG GO_VERSION
+
+# Get bugsnag dependencies using a conditional call to run go get or go install based on the go version
+RUN if [[ $(echo -e "1.11\n$GO_VERSION\n1.16" | sort -V | head -2 | tail -1) == "$GO_VERSION" ]]; then \
+        echo "Version is between 1.11 and 1.16, running go get"; \
+        go get ./...; \
+    else \
+        echo "Version is greater than 1.16, running go install"; \
+        go install ./...; \
+    fi
 
 # Copy test scenarios
 COPY ./autoconfigure /app/src/test
 WORKDIR /app/src/test
 
-# Ensure subsequent steps are re-run if the GO_VERSION variable changes
-ARG GO_VERSION
 # Create app module - avoid locking bugsnag dep by not checking it in
 # Skip on old versions of Go which pre-date modules
 RUN if [[ $GO_VERSION != '1.11' && $GO_VERSION != '1.12' ]]; then \

--- a/features/fixtures/net_http/Dockerfile
+++ b/features/fixtures/net_http/Dockerfile
@@ -10,15 +10,22 @@ ENV GOPATH /app
 COPY testbuild /app/src/github.com/bugsnag/bugsnag-go
 WORKDIR /app/src/github.com/bugsnag/bugsnag-go/v2
 
-# Get bugsnag dependencies
-RUN go get ./...
+# Ensure subsequent steps are re-run if the GO_VERSION variable changes
+ARG GO_VERSION
+
+# Get bugsnag dependencies using a conditional call to run go get or go install based on the go version
+RUN if [[ $(echo -e "1.11\n$GO_VERSION\n1.16" | sort -V | head -2 | tail -1) == "$GO_VERSION" ]]; then \
+        echo "Version is between 1.11 and 1.16, running go get"; \
+        go get ./...; \
+    else \
+        echo "Version is greater than 1.16, running go install"; \
+        go install ./...; \
+    fi
 
 # Copy test scenarios
 COPY ./net_http /app/src/test
 WORKDIR /app/src/test
 
-# Ensure subsequent steps are re-run if the GO_VERSION variable changes
-ARG GO_VERSION
 # Create app module - avoid locking bugsnag dep by not checking it in
 # Skip on old versions of Go which pre-date modules
 RUN if [[ $GO_VERSION != '1.11' && $GO_VERSION != '1.12' ]]; then \


### PR DESCRIPTION
## Goal

Update test matrix to include latest versions of Go.

## Design

Make sure building with the latest versions of Go is successful and monitor how long it takes to build.

## Changeset

Added latest Go versions, `v1.17 - v1.22`, to test-matrix. 

Updated the `unhandledCrash()` function in `main.go` with `noinline` to accommodate the inline function behavior introduced in `v1.17+`.

Updated the `RUN` commands in all Dockerfile(s) to a conditional to use `go get` or `go install` dependent on the version of Go being used.

Moved `ARG GO_VERSION` up to allow consumption by `RUN` command.

## Testing

Relying on testing via CI. 