### PR TITLE
fix middleware panic on nil *http.Request

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -62,7 +62,7 @@ func catchMiddlewarePanic(event *Event, config *Configuration, next func() error
 // use this as a template for writing your own Middleware.
 func httpRequestMiddleware(event *Event, config *Configuration) error {
 	for _, datum := range event.RawData {
-		if request, ok := datum.(*http.Request); ok {
+		if request, ok := datum.(*http.Request); ok && request != nil {
 			event.MetaData.Update(MetaData{
 				"request": {
 					"params": request.URL.Query(),

--- a/v2/middleware.go
+++ b/v2/middleware.go
@@ -57,7 +57,7 @@ func (stack *middlewareStack) runBeforeFilter(f beforeFunc, event *Event, config
 // use this as a template for writing your own Middleware.
 func httpRequestMiddleware(event *Event, config *Configuration) error {
 	for _, datum := range event.RawData {
-		if request, ok := datum.(*http.Request); ok {
+		if request, ok := datum.(*http.Request); ok && request != nil {
 			event.MetaData.Update(MetaData{
 				"request": {
 					"params": request.URL.Query(),


### PR DESCRIPTION
## Goal

Currently bugsnag's middleware panics on nil *http.Request

https://go.dev/play/p/5EkLul6ay5y?v=goprev

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

This was observed on another project using bugsnag.