### PR TITLE
Fix the order of trimming paths of inProject files

### DIFF
--- a/v2/configuration.go
+++ b/v2/configuration.go
@@ -232,10 +232,7 @@ func (config *Configuration) isProjectPackage(_pkg string) bool {
 }
 
 func (config *Configuration) stripProjectPackages(file string) string {
-	trimmedFile := file
-	if strings.HasPrefix(trimmedFile, config.SourceRoot) {
-		trimmedFile = strings.TrimPrefix(trimmedFile, config.SourceRoot)
-	}
+	trimmedFile := strings.TrimPrefix(file, config.SourceRoot)
 	for _, p := range config.ProjectPackages {
 		if len(p) > 2 && p[len(p)-2] == '/' && p[len(p)-1] == '*' {
 			p = p[:len(p)-1]

--- a/v2/event.go
+++ b/v2/event.go
@@ -197,12 +197,13 @@ func generateStacktrace(err *errors.Error, config *Configuration) []StackFrame {
 		file := frame.File
 		inProject := config.isProjectPackage(frame.Package)
 
-		// remove $GOROOT and $GOHOME from other frames
-		if idx := strings.Index(file, frame.Package); idx > -1 {
-			file = file[idx:]
-		}
 		if inProject {
 			file = config.stripProjectPackages(file)
+		} else {
+			// remove $GOROOT and $GOHOME from other frames
+			if idx := strings.Index(file, frame.Package); idx > -1 {
+				file = file[idx:]
+			}
 		}
 
 		stack[i] = StackFrame{


### PR DESCRIPTION
## Goal
In case of different main files it's impossible to differentiate where the error came from.

## Design
Current implementation **WITHOUT** setting `SourceRoot` and `ProjectPackages` produces event like this:
<img width="594" alt="Screenshot 2024-02-22 at 17 24 00" src="https://github.com/bugsnag/bugsnag-go/assets/88393714/497486f9-f4c6-49c7-a08f-feba2062f0c2">
Current implementation **WITH** configuration:
<img width="447" alt="Screenshot 2024-02-22 at 17 43 43" src="https://github.com/bugsnag/bugsnag-go/assets/88393714/32024787-63ff-4700-82a0-037a9d3c9957">

Changes in this PR **WITHOUT** any configuration:
<img width="583" alt="Screenshot 2024-02-22 at 17 26 00" src="https://github.com/bugsnag/bugsnag-go/assets/88393714/0c83ce99-d1e2-4c78-8933-9cba6841490a">
Changes in this PR with `SourceRoot` configured:
<img width="595" alt="Screenshot 2024-02-22 at 17 26 58" src="https://github.com/bugsnag/bugsnag-go/assets/88393714/72b146f5-c270-4b48-8001-88ba351a6e12">
Changes in this PR with `SourceRoot` and `ProjectPackages` configured:
<img width="470" alt="Screenshot 2024-02-22 at 17 38 37" src="https://github.com/bugsnag/bugsnag-go/assets/88393714/fc43e9a8-19cc-418f-bb9e-abb7fac2c949">

## Changeset
If the file is in project trim `SourceRoot` from the filepath, for outsider files trim GOROOT and GOPATH if they are set.
It's impossible to get SourceRoot programmatically at runtime. We can get info about module to add to ProjectPackages along with main but it will work only if called from main file.

## Testing
-