### PR TITLE
Fix middleware panic on nil *http.Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.2.1 (2022-02-21)
+
+### Bug fixes
+
+* Fix middleware panic on nil *http.Request
+  [#212](https://github.com/bugsnag/bugsnag-go/pull/212)
+
 ## 2.2.0 (2022-10-12)
 
 ### Enhancements

--- a/middleware.go
+++ b/middleware.go
@@ -62,7 +62,7 @@ func catchMiddlewarePanic(event *Event, config *Configuration, next func() error
 // use this as a template for writing your own Middleware.
 func httpRequestMiddleware(event *Event, config *Configuration) error {
 	for _, datum := range event.RawData {
-		if request, ok := datum.(*http.Request); ok {
+		if request, ok := datum.(*http.Request); ok && request != nil {
 			event.MetaData.Update(MetaData{
 				"request": {
 					"params": request.URL.Query(),

--- a/v2/middleware.go
+++ b/v2/middleware.go
@@ -57,7 +57,7 @@ func (stack *middlewareStack) runBeforeFilter(f beforeFunc, event *Event, config
 // use this as a template for writing your own Middleware.
 func httpRequestMiddleware(event *Event, config *Configuration) error {
 	for _, datum := range event.RawData {
-		if request, ok := datum.(*http.Request); ok {
+		if request, ok := datum.(*http.Request); ok && request != nil {
 			event.MetaData.Update(MetaData{
 				"request": {
 					"params": request.URL.Query(),

--- a/v2/middleware_test.go
+++ b/v2/middleware_test.go
@@ -3,10 +3,12 @@ package bugsnag
 import (
 	"bytes"
 	"fmt"
-	"github.com/bugsnag/bugsnag-go/v2/errors"
 	"log"
+	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/bugsnag/bugsnag-go/v2/errors"
 )
 
 func TestMiddlewareOrder(t *testing.T) {
@@ -93,5 +95,17 @@ func TestBeforeNotifyPanic(t *testing.T) {
 
 	if called == false {
 		t.Errorf("Notify was not called when BeforeNotify panicked")
+	}
+}
+
+func TestHttpRequestMiddleware(t *testing.T) {
+	var req *http.Request
+	rawData := []interface{}{req}
+
+	event := &Event{RawData: rawData}
+	config := &Configuration{}
+	err := httpRequestMiddleware(event, config)
+	if err != nil {
+		t.Errorf("Should not happen")
 	}
 }


### PR DESCRIPTION
## Goal
One of the two default OnBeforeNotify callbacks was panicking if http request in Event's RawData was nil.
Check for nil request added (https://github.com/bugsnag/bugsnag-go/pull/210).

## Design
-

## Changeset
Added check for nil http.Request in `httpRequestMiddleware` callback.

## Testing
Added unit tests for nil request scenario. 