### PR TITLE
Handle complex structs in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Start showing inlined functions in stack trace
   [#208](https://github.com/bugsnag/bugsnag-go/pull/208)
 
+* Handle complex structs in metadata
+  [#215](https://github.com/bugsnag/bugsnag-go/pull/215)
+  [Chris Duncan](https://github.com/veqryn)
+
 ## 2.2.0 (2022-10-12)
 
 ### Enhancements

--- a/v2/metadata.go
+++ b/v2/metadata.go
@@ -97,9 +97,8 @@ func (s Sanitizer) Sanitize(data interface{}) interface{} {
 		// This also covers time.Duration
 		return data.String()
 
-	case encoding.TextUnmarshaler:
-		var b []byte
-		if err := data.UnmarshalText(b); err == nil {
+	case encoding.TextMarshaler:
+		if b, err := data.MarshalText(); err == nil {
 			return string(b)
 		}
 	}

--- a/v2/metadata.go
+++ b/v2/metadata.go
@@ -46,7 +46,7 @@ func (meta MetaData) Add(tab string, key string, value interface{}) {
 // As a safety measure, if you pass a non-struct the value will be
 // sent to Bugsnag under the "Extra data" tab.
 func (meta MetaData) AddStruct(tab string, obj interface{}) {
-	val := Sanitizer{}.Sanitize(obj)
+	val := sanitizer{}.Sanitize(obj)
 	content, ok := val.(map[string]interface{})
 	if ok {
 		meta[tab] = content
@@ -60,20 +60,20 @@ func (meta MetaData) AddStruct(tab string, obj interface{}) {
 // Remove any values from meta-data that have keys matching the filters,
 // and any that are recursive data-structures
 func (meta MetaData) sanitize(filters []string) interface{} {
-	return Sanitizer{
+	return sanitizer{
 		Filters: filters,
 		Seen:    make([]interface{}, 0),
 	}.Sanitize(meta)
 
 }
 
-// Sanitizer is used to remove filtered params and recursion from meta-data.
-type Sanitizer struct {
+// sanitizer is used to remove filtered params and recursion from meta-data.
+type sanitizer struct {
 	Filters []string
 	Seen    []interface{}
 }
 
-func (s Sanitizer) Sanitize(data interface{}) interface{} {
+func (s sanitizer) Sanitize(data interface{}) interface{} {
 	for _, s := range s.Seen {
 		// TODO: we don't need deep equal here, just type-ignoring equality
 		if reflect.DeepEqual(data, s) {
@@ -146,7 +146,7 @@ func (s Sanitizer) Sanitize(data interface{}) interface{} {
 	}
 }
 
-func (s Sanitizer) sanitizeMap(v reflect.Value) interface{} {
+func (s sanitizer) sanitizeMap(v reflect.Value) interface{} {
 	ret := make(map[string]interface{})
 
 	for _, key := range v.MapKeys() {
@@ -163,7 +163,7 @@ func (s Sanitizer) sanitizeMap(v reflect.Value) interface{} {
 	return ret
 }
 
-func (s Sanitizer) sanitizeStruct(v reflect.Value, t reflect.Type) interface{} {
+func (s sanitizer) sanitizeStruct(v reflect.Value, t reflect.Type) interface{} {
 	ret := make(map[string]interface{})
 
 	for i := 0; i < v.NumField(); i++ {
@@ -199,7 +199,7 @@ func (s Sanitizer) sanitizeStruct(v reflect.Value, t reflect.Type) interface{} {
 	return ret
 }
 
-func (s Sanitizer) shouldRedact(key string) bool {
+func (s sanitizer) shouldRedact(key string) bool {
 	for _, filter := range s.Filters {
 		if strings.Contains(strings.ToLower(key), strings.ToLower(filter)) {
 			return true

--- a/v2/metadata_test.go
+++ b/v2/metadata_test.go
@@ -201,7 +201,7 @@ func TestSanitizerSanitize(t *testing.T) {
 		{nilPointer, "<nil>"},
 		{nilInterface, "<nil>"},
 	} {
-		s := &Sanitizer{}
+		s := &sanitizer{}
 		gotValue := s.Sanitize(tc.input)
 
 		if got, want := gotValue, tc.want; got != want {

--- a/v2/metadata_test.go
+++ b/v2/metadata_test.go
@@ -1,8 +1,10 @@
 package bugsnag
 
 import (
+	stderrors "errors"
 	"reflect"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/bugsnag/bugsnag-go/v2/errors"
@@ -24,6 +26,12 @@ type _account struct {
 type _broken struct {
 	Me   *_broken
 	Data string
+}
+
+type _textMarshaller struct{}
+
+func (_textMarshaller) MarshalText() ([]byte, error) {
+	return []byte("marshalled text"), nil
 }
 
 var account = _account{}
@@ -123,6 +131,10 @@ func TestMetaDataSanitize(t *testing.T) {
 			"unsafe":   unsafe.Pointer(broken.Me),
 			"string":   "string",
 			"password": "secret",
+			"error":    stderrors.New("some error"),
+			"time":     time.Date(2023, 12, 5, 23, 59, 59, 123456789, time.UTC),
+			"duration": 105567462 * time.Millisecond,
+			"text":     _textMarshaller{},
 			"array": []hash{{
 				"creditcard": "1234567812345678",
 				"broken":     broken,
@@ -144,6 +156,10 @@ func TestMetaDataSanitize(t *testing.T) {
 			"unsafe":   "[unsafe.Pointer]",
 			"func":     "[func()]",
 			"password": "[FILTERED]",
+			"error":    "some error",
+			"time":     "2023-12-05T23:59:59.123456789Z",
+			"duration": "29h19m27.462s",
+			"text":     "marshalled text",
 			"array": []interface{}{map[string]interface{}{
 				"creditcard": "[FILTERED]",
 				"broken": map[string]interface{}{

--- a/v2/metadata_test.go
+++ b/v2/metadata_test.go
@@ -185,7 +185,7 @@ func TestSanitizerSanitize(t *testing.T) {
 		{nilPointer, "<nil>"},
 		{nilInterface, "<nil>"},
 	} {
-		s := &sanitizer{}
+		s := &Sanitizer{}
 		gotValue := s.Sanitize(tc.input)
 
 		if got, want := gotValue, tc.want; got != want {


### PR DESCRIPTION
## Goal
New fields with complex struct types in metadata could not be properly processed and resulted in "{}" in output.

## Design
-

## Changeset
Added handling for known complex types like date and time, errors, stringers.

## Testing
Unit tests added.