### PR TITLE
Stop trimming everything before "main.go" on main packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   [#215](https://github.com/bugsnag/bugsnag-go/pull/215)
   [Chris Duncan](https://github.com/veqryn)
 
+* Stop trimming everything before "main.go" on main packages
+  [#217](https://github.com/bugsnag/bugsnag-go/pull/217)
+  [Chris Duncan](https://github.com/veqryn)
+
 ## 2.2.0 (2022-10-12)
 
 ### Enhancements

--- a/event.go
+++ b/event.go
@@ -198,7 +198,7 @@ func generateStacktrace(err *errors.Error, config *Configuration) []StackFrame {
 		inProject := config.isProjectPackage(frame.Package)
 
 		// remove $GOROOT and $GOHOME from other frames
-		if idx := strings.Index(file, frame.Package); idx > -1 && frame.Package != "main" {
+		if idx := strings.Index(file, frame.Package); idx > -1 {
 			file = file[idx:]
 		}
 		if inProject {

--- a/event.go
+++ b/event.go
@@ -198,7 +198,7 @@ func generateStacktrace(err *errors.Error, config *Configuration) []StackFrame {
 		inProject := config.isProjectPackage(frame.Package)
 
 		// remove $GOROOT and $GOHOME from other frames
-		if idx := strings.Index(file, frame.Package); idx > -1 {
+		if idx := strings.Index(file, frame.Package); idx > -1 && frame.Package != "main" {
 			file = file[idx:]
 		}
 		if inProject {

--- a/features/fixtures/app/main.go
+++ b/features/fixtures/app/main.go
@@ -130,6 +130,7 @@ func multipleUnhandled() {
 	defer notifier.AutoNotify(ctx)
 	panic("oops")
 }
+
 //go:noinline
 func unhandledCrash() {
 	// Invalid type assertion, will panic
@@ -259,17 +260,17 @@ func handledToUnhandled() {
 }
 
 type customErr struct {
-	msg string
-	cause error
+	msg     string
+	cause   error
 	callers []uintptr
 }
 
 func newCustomErr(msg string, cause error) error {
 	callers := make([]uintptr, 8)
 	runtime.Callers(2, callers)
-	return customErr {
-		msg: msg,
-		cause: cause,
+	return customErr{
+		msg:     msg,
+		cause:   cause,
 		callers: callers,
 	}
 }
@@ -297,7 +298,7 @@ func nestedHandledError() {
 		if val, err := checkValue(i); err != nil {
 			fmt.Printf("err: %v, val: %d", err, val)
 		}
-		if val, err := checkValue(i-46); err != nil {
+		if val, err := checkValue(i - 46); err != nil {
 			fmt.Printf("err: %v, val: %d", err, val)
 		}
 
@@ -317,7 +318,7 @@ func login(token string) error {
 func checkValue(i int) (int, error) {
 	if i < 0 {
 		return 0, newCustomErr("invalid token", nil)
-	} else if i % 2 == 0 {
+	} else if i%2 == 0 {
 		return i / 2, nil
 	} else if i < 9 {
 		return i * 3, nil

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - PARAMS_FILTERS
       - SYNCHRONOUS
       - SERVER_PORT
+      - BUGSNAG_SOURCE_ROOT
+      - BUGSNAG_PROJECT_PACKAGES
     restart: "no"
 
   autoconfigure:
@@ -72,6 +74,8 @@ services:
       - AUTO_CAPTURE_SESSIONS
       - SYNCHRONOUS
       - SERVER_PORT
+      - BUGSNAG_SOURCE_ROOT
+      - BUGSNAG_PROJECT_PACKAGES
     restart: "no"
     command: go run main.go
 
@@ -97,6 +101,8 @@ services:
       - AUTO_CAPTURE_SESSIONS
       - SYNCHRONOUS
       - SERVER_PORT
+      - BUGSNAG_SOURCE_ROOT
+      - BUGSNAG_PROJECT_PACKAGES
     restart: "no"
     command: go run main.go
 
@@ -121,6 +127,8 @@ services:
       - AUTO_CAPTURE_SESSIONS
       - SYNCHRONOUS
       - SERVER_PORT
+      - BUGSNAG_SOURCE_ROOT
+      - BUGSNAG_PROJECT_PACKAGES
     restart: "no"
     command: go run main.go
 
@@ -146,6 +154,8 @@ services:
       - AUTO_CAPTURE_SESSIONS
       - SYNCHRONOUS
       - SERVER_PORT
+      - BUGSNAG_SOURCE_ROOT
+      - BUGSNAG_PROJECT_PACKAGES
     restart: "no"
     command: go run main.go
 
@@ -173,5 +183,7 @@ services:
       - SYNCHRONOUS
       - SERVER_PORT
       - USE_PROPERTIES_FILE_CONFIG
+      - BUGSNAG_SOURCE_ROOT
+      - BUGSNAG_PROJECT_PACKAGES
     restart: "no"
     command: ./test/run.sh

--- a/features/handled.feature
+++ b/features/handled.feature
@@ -2,6 +2,7 @@ Feature: Plain handled errors
 
 Background:
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  Given I set environment variable "BUGSNAG_SOURCE_ROOT" to the app directory
   And I configure the bugsnag endpoint
   And I have built the service "app"
   And I set environment variable "AUTO_CAPTURE_SESSIONS" to "false"
@@ -14,7 +15,7 @@ Scenario: A handled error sends a report
   And the event "severity" equals "warning"
   And the event "severityReason.type" equals "handledError"
   And the exception is a PathError for request 0
-  And the "file" of stack frame 0 ends with "main.go"
+  And the "file" of stack frame 0 equals "main.go"
 
 Scenario: A handled error sends a report with a custom name
   Given I set environment variable "ERROR_CLASS" to "MyCustomErrorClass"
@@ -25,7 +26,7 @@ Scenario: A handled error sends a report with a custom name
   And the event "severity" equals "warning"
   And the event "severityReason.type" equals "handledError"
   And the exception "errorClass" equals "MyCustomErrorClass"
-  And the "file" of stack frame 0 ends with "main.go"
+  And the "file" of stack frame 0 equals "main.go"
 
 Scenario: Sending an event using a callback to modify report contents
   When I run the go service "app" with the test case "handled-with-callback"
@@ -35,7 +36,7 @@ Scenario: Sending an event using a callback to modify report contents
   And the event "severity" equals "info"
   And the event "severityReason.type" equals "userCallbackSetSeverity"
   And the event "context" equals "nonfatal.go:14"
-  And the "file" of stack frame 0 ends with "main.go"
+  And the "file" of stack frame 0 equals "main.go"
   And stack frame 0 contains a local function spanning 242 to 248
   And the "file" of stack frame 1 equals ">insertion<"
   And the "lineNumber" of stack frame 1 equals 0
@@ -48,7 +49,7 @@ Scenario: Marking an error as unhandled in a callback
   And the event "severity" equals "error"
   And the event "severityReason.type" equals "userCallbackSetSeverity"
   And the event "severityReason.unhandledOverridden" is true
-  And the "file" of stack frame 0 ends with "main.go"
+  And the "file" of stack frame 0 equals "main.go"
   And stack frame 0 contains a local function spanning 254 to 257
 
 Scenario: Unwrapping the causes of a handled error
@@ -59,11 +60,11 @@ Scenario: Unwrapping the causes of a handled error
   And the event "severity" equals "warning"
   And the event "exceptions.0.message" equals "terminate process"
   And the "lineNumber" of stack frame 0 equals 292
-  And the "file" of stack frame 0 ends with "main.go"
+  And the "file" of stack frame 0 equals "main.go"
   And the "method" of stack frame 0 equals "nestedHandledError"
   And the event "exceptions.1.message" equals "login failed"
-  And the event "exceptions.1.stacktrace.0.file" ends with "main.go"
+  And the event "exceptions.1.stacktrace.0.file" equals "main.go"
   And the event "exceptions.1.stacktrace.0.lineNumber" equals 312
   And the event "exceptions.2.message" equals "invalid token"
-  And the event "exceptions.2.stacktrace.0.file" ends with "main.go"
+  And the event "exceptions.2.stacktrace.0.file" equals "main.go"
   And the event "exceptions.2.stacktrace.0.lineNumber" equals 320

--- a/features/handled.feature
+++ b/features/handled.feature
@@ -14,7 +14,7 @@ Scenario: A handled error sends a report
   And the event "severity" equals "warning"
   And the event "severityReason.type" equals "handledError"
   And the exception is a PathError for request 0
-  And the "file" of stack frame 0 equals "main.go"
+  And the "file" of stack frame 0 ends with "main.go"
 
 Scenario: A handled error sends a report with a custom name
   Given I set environment variable "ERROR_CLASS" to "MyCustomErrorClass"
@@ -25,7 +25,7 @@ Scenario: A handled error sends a report with a custom name
   And the event "severity" equals "warning"
   And the event "severityReason.type" equals "handledError"
   And the exception "errorClass" equals "MyCustomErrorClass"
-  And the "file" of stack frame 0 equals "main.go"
+  And the "file" of stack frame 0 ends with "main.go"
 
 Scenario: Sending an event using a callback to modify report contents
   When I run the go service "app" with the test case "handled-with-callback"
@@ -35,8 +35,8 @@ Scenario: Sending an event using a callback to modify report contents
   And the event "severity" equals "info"
   And the event "severityReason.type" equals "userCallbackSetSeverity"
   And the event "context" equals "nonfatal.go:14"
-  And the "file" of stack frame 0 equals "main.go"
-  And stack frame 0 contains a local function spanning 241 to 247
+  And the "file" of stack frame 0 ends with "main.go"
+  And stack frame 0 contains a local function spanning 242 to 248
   And the "file" of stack frame 1 equals ">insertion<"
   And the "lineNumber" of stack frame 1 equals 0
 
@@ -48,8 +48,8 @@ Scenario: Marking an error as unhandled in a callback
   And the event "severity" equals "error"
   And the event "severityReason.type" equals "userCallbackSetSeverity"
   And the event "severityReason.unhandledOverridden" is true
-  And the "file" of stack frame 0 equals "main.go"
-  And stack frame 0 contains a local function spanning 253 to 256
+  And the "file" of stack frame 0 ends with "main.go"
+  And stack frame 0 contains a local function spanning 254 to 257
 
 Scenario: Unwrapping the causes of a handled error
   When I run the go service "app" with the test case "nested-error"
@@ -58,12 +58,12 @@ Scenario: Unwrapping the causes of a handled error
   And the event "unhandled" is false
   And the event "severity" equals "warning"
   And the event "exceptions.0.message" equals "terminate process"
-  And the "lineNumber" of stack frame 0 equals 291
-  And the "file" of stack frame 0 equals "main.go"
+  And the "lineNumber" of stack frame 0 equals 292
+  And the "file" of stack frame 0 ends with "main.go"
   And the "method" of stack frame 0 equals "nestedHandledError"
   And the event "exceptions.1.message" equals "login failed"
-  And the event "exceptions.1.stacktrace.0.file" equals "main.go"
-  And the event "exceptions.1.stacktrace.0.lineNumber" equals 311
+  And the event "exceptions.1.stacktrace.0.file" ends with "main.go"
+  And the event "exceptions.1.stacktrace.0.lineNumber" equals 312
   And the event "exceptions.2.message" equals "invalid token"
-  And the event "exceptions.2.stacktrace.0.file" equals "main.go"
-  And the event "exceptions.2.stacktrace.0.lineNumber" equals 319
+  And the event "exceptions.2.stacktrace.0.file" ends with "main.go"
+  And the event "exceptions.2.stacktrace.0.lineNumber" equals 320

--- a/features/net-http/handled.feature
+++ b/features/net-http/handled.feature
@@ -17,7 +17,7 @@ Scenario: A handled error sends a report
   And the event "severity" equals "warning" for request 0
   And the event "severityReason.type" equals "handledError" for request 0
   And the exception is a PathError for request 0
-  And the "file" of stack frame 0 equals "main.go" for request 0
+  And the "file" of stack frame 0 ends with "main.go" for request 0
 
 Scenario: A handled error sends a report with a custom name
   Given I set environment variable "ERROR_CLASS" to "MyCustomErrorClass"
@@ -31,4 +31,4 @@ Scenario: A handled error sends a report with a custom name
   And the event "severity" equals "warning" for request 0
   And the event "severityReason.type" equals "handledError" for request 0
   And the exception "errorClass" equals "MyCustomErrorClass" for request 0
-  And the "file" of stack frame 0 equals "main.go" for request 0
+  And the "file" of stack frame 0 ends with "main.go" for request 0

--- a/features/net-http/handled.feature
+++ b/features/net-http/handled.feature
@@ -2,6 +2,7 @@ Feature: Handled errors
 
 Background:
   Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  Given I set environment variable "BUGSNAG_SOURCE_ROOT" to the app directory
   And I configure the bugsnag endpoint
   And I set environment variable "SERVER_PORT" to "4512"
   And I set environment variable "AUTO_CAPTURE_SESSIONS" to "false"
@@ -17,7 +18,7 @@ Scenario: A handled error sends a report
   And the event "severity" equals "warning" for request 0
   And the event "severityReason.type" equals "handledError" for request 0
   And the exception is a PathError for request 0
-  And the "file" of stack frame 0 ends with "main.go" for request 0
+  And the "file" of stack frame 0 equals "main.go" for request 0
 
 Scenario: A handled error sends a report with a custom name
   Given I set environment variable "ERROR_CLASS" to "MyCustomErrorClass"
@@ -31,4 +32,4 @@ Scenario: A handled error sends a report with a custom name
   And the event "severity" equals "warning" for request 0
   And the event "severityReason.type" equals "handledError" for request 0
   And the exception "errorClass" equals "MyCustomErrorClass" for request 0
-  And the "file" of stack frame 0 ends with "main.go" for request 0
+  And the "file" of stack frame 0 equals "main.go" for request 0

--- a/features/plain_features/panics.feature
+++ b/features/plain_features/panics.feature
@@ -17,7 +17,7 @@ Feature: Panic handling
       And the exception "message" is one of:
         | interface conversion: interface is struct {}, not string      |
         | interface conversion: interface {} is struct {}, not string   |
-      And the in-project frames of the stacktrace are:
-        | file    | method               |
-        | main.go | unhandledCrash.func1 |
-        | main.go | unhandledCrash       |
+      And the "method" of stack frame 0 equals "unhandledCrash.func1"
+      And the "file" of stack frame 0 ends with "main.go"
+      And the "method" of stack frame 1 equals "unhandledCrash"
+      And the "file" of stack frame 1 ends with "main.go"

--- a/features/plain_features/panics.feature
+++ b/features/plain_features/panics.feature
@@ -2,6 +2,7 @@ Feature: Panic handling
 
     Background:
       Given I set environment variable "API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+      Given I set environment variable "BUGSNAG_SOURCE_ROOT" to the app directory
       And I configure the bugsnag endpoint
       And I have built the service "app"
       And I set environment variable "AUTO_CAPTURE_SESSIONS" to "false"
@@ -17,7 +18,7 @@ Feature: Panic handling
       And the exception "message" is one of:
         | interface conversion: interface is struct {}, not string      |
         | interface conversion: interface {} is struct {}, not string   |
-      And the "method" of stack frame 0 equals "unhandledCrash.func1"
-      And the "file" of stack frame 0 ends with "main.go"
-      And the "method" of stack frame 1 equals "unhandledCrash"
-      And the "file" of stack frame 1 ends with "main.go"
+      And the in-project frames of the stacktrace are:
+        | file    | method               |
+        | main.go | unhandledCrash.func1 |
+        | main.go | unhandledCrash       |

--- a/v2/configuration.go
+++ b/v2/configuration.go
@@ -232,10 +232,7 @@ func (config *Configuration) isProjectPackage(_pkg string) bool {
 }
 
 func (config *Configuration) stripProjectPackages(file string) string {
-	trimmedFile := file
-	if strings.HasPrefix(trimmedFile, config.SourceRoot) {
-		trimmedFile = strings.TrimPrefix(trimmedFile, config.SourceRoot)
-	}
+	trimmedFile := strings.TrimPrefix(file, config.SourceRoot)
 	for _, p := range config.ProjectPackages {
 		if len(p) > 2 && p[len(p)-2] == '/' && p[len(p)-1] == '*' {
 			p = p[:len(p)-1]

--- a/v2/event.go
+++ b/v2/event.go
@@ -198,7 +198,7 @@ func generateStacktrace(err *errors.Error, config *Configuration) []StackFrame {
 		inProject := config.isProjectPackage(frame.Package)
 
 		// remove $GOROOT and $GOHOME from other frames
-		if idx := strings.Index(file, frame.Package); idx > -1 {
+		if idx := strings.Index(file, frame.Package); idx > -1 && frame.Package != "main" {
 			file = file[idx:]
 		}
 		if inProject {

--- a/v2/event.go
+++ b/v2/event.go
@@ -197,10 +197,19 @@ func generateStacktrace(err *errors.Error, config *Configuration) []StackFrame {
 		file := frame.File
 		inProject := config.isProjectPackage(frame.Package)
 
-		// remove $GOROOT and $GOHOME from other frames
+		// This will trim path before package name for external packages and golang default packages
+		// Excluding main package as it's special case
+		// This will NOT trim paths for packages in current module because path won't contain the package name
+		// Example: path is "/user/name/work/internal/internal.go" and module package name is "example.com/mymodule/internal"
 		if idx := strings.Index(file, frame.Package); idx > -1 && frame.Package != "main" {
 			file = file[idx:]
 		}
+
+		// This should trim path for main and other current module packages with correct config
+		// If input path is "/user/name/work/internal/internal.go"
+		// SourceRoot is "/user/name/work" and ProjectPackages are []string{"main*", "example.com/mymodule/**"}
+		// Then when package name is "example.com/mymodule/internal"
+		// The path will be trimmed to "/internal/internal.go"
 		if inProject {
 			file = config.stripProjectPackages(file)
 		}


### PR DESCRIPTION
## Goal
In case of different main files it's impossible to differentiate which main file the error came from.

## Design
It's less invasive than correcting the order of trimming paths. (#211)
First trimming is performed for every package and it trims everything until the package name.
It's mostly for external packages or golang internal pkg.
Because `main` is a special package (pkg name is just "main" without module) we omit it in the first trimming.
Then if it's added to ProjectPackages and SourceRoot is properly configured the path will be trimmed properly.
So for input path: "/user/name/work/cmd/main.go"
current solution will provide: "main.go"
and this PR's solution will provide either "/user/name/work/cmd/main.go" or "cmd/main.go" depending of whether SourceRoot is configured.

## Changeset
Skipped trimming path for "main" package.

## Testing
Adjusted maze tests - for testcases that check `main.go` line numbers we setup `SourceRoot` so that main's path is trimmed correctly.