### PR TITLE
Fix session tracking test - wait for all sessions to be processed

### DIFF
--- a/v2/sessions/tracker_test.go
+++ b/v2/sessions/tracker_test.go
@@ -55,7 +55,7 @@ func TestShouldOnlyWriteWhenReceivingSessions(t *testing.T) {
 	for i := 0; i < 50000; i++ {
 		st.StartSession(context.Background())
 	}
-	time.Sleep(st.config.PublishInterval * 2)
+	time.Sleep(time.Millisecond * 500) // wait for sessions to get consumed
 
 	var sessions []*Session
 	pub.mutex.Lock()


### PR DESCRIPTION
## Goal
Session counting test was flaky - probably did not wait for all the sessions to be consumed.

## Design
-

## Changeset
Increased wait duration after sessions were created so they can be all consumed by `st.processSessions` thread.

## Testing
Unit tests for session tracker changed.