### PR TITLE
Handle empty pointers to complex structs in metadata.Add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## TBD
+## 2.3.1 (2024-03-18)
+
+### Bug fixes
+
+* Handle empty pointers to complex structs in metadata.Add
+  [#221](https://github.com/bugsnag/bugsnag-go/pull/221)
+
+## 2.3.0 (2024-03-05)
 
 ### Bug fixes
 

--- a/v2/metadata_test.go
+++ b/v2/metadata_test.go
@@ -34,6 +34,12 @@ func (_textMarshaller) MarshalText() ([]byte, error) {
 	return []byte("marshalled text"), nil
 }
 
+type _testStringer struct{}
+
+func (s _testStringer) String() string {
+	return "something"
+}
+
 var account = _account{}
 var notifier = New(Configuration{})
 
@@ -74,6 +80,23 @@ func TestMetaDataAdd(t *testing.T) {
 		},
 	}) {
 		t.Errorf("metadata.Add didn't work: %#v", m)
+	}
+}
+
+func TestMetadataAddPointer(t *testing.T) {
+	var pointer *_testStringer
+	md := MetaData{}
+	md.AddStruct("emptypointer", pointer)
+	fullPointer := &_testStringer{}
+	md.AddStruct("fullpointer", fullPointer)
+
+	if !reflect.DeepEqual(md, MetaData{
+		"Extra data": {
+			"emptypointer": "<nil>",
+			"fullpointer":  "something",
+		},
+	}) {
+		t.Errorf("metadata.AddStruct didn't work: %#v", md)
 	}
 }
 


### PR DESCRIPTION
## Goal
When we pass a pointer to complex interface (that in Sanitizer gets caught in type switch-case) we don't check if the pointer is nil.
Type specific switch-case tried to check for interface function `String()` for `fmt.Stringer` interface on the nil pointer leading to a panic.

## Changeset
Moved check for nil pointers and interfaces before any other type matching is done.
In `metadata.AddStruct` used an actual sanitized value to pass into `metadata.Add`.

## Testing
New tests for adding pointers with Stringer interface to metadata - either nil ptr or normal.