### PR TITLE
Sanitize should also handler json and []byte

### DIFF
--- a/v2/metadata.go
+++ b/v2/metadata.go
@@ -2,6 +2,7 @@ package bugsnag
 
 import (
 	"encoding"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -112,6 +113,11 @@ func (s sanitizer) Sanitize(data interface{}) interface{} {
 
 	case encoding.TextMarshaler:
 		if b, err := dataT.MarshalText(); err == nil {
+			return string(b)
+		}
+
+	case json.Marshaler:
+		if b, err := dataT.MarshalJSON(); err == nil {
 			return string(b)
 		}
 	}

--- a/v2/metadata.go
+++ b/v2/metadata.go
@@ -99,7 +99,7 @@ func (s sanitizer) Sanitize(data interface{}) interface{} {
 		}
 	}
 
-	// Handle certain well known interfaces and types
+	// Handle certain well known interfaces and types, in preferred order
 	switch dataT := data.(type) {
 	case error:
 		return dataT.Error()
@@ -120,6 +120,9 @@ func (s sanitizer) Sanitize(data interface{}) interface{} {
 		if b, err := dataT.MarshalJSON(); err == nil {
 			return string(b)
 		}
+
+	case []byte:
+		return string(dataT)
 	}
 
 	switch t.Kind() {

--- a/v2/metadata_test.go
+++ b/v2/metadata_test.go
@@ -1,6 +1,7 @@
 package bugsnag
 
 import (
+	"encoding/json"
 	stderrors "errors"
 	"reflect"
 	"testing"
@@ -215,6 +216,7 @@ func TestMetaDataSanitize(t *testing.T) {
 			"time":     time.Date(2023, 12, 5, 23, 59, 59, 123456789, time.UTC),
 			"duration": 105567462 * time.Millisecond,
 			"text":     _textMarshaller{},
+			"json":     json.RawMessage(`{"hello": "world"}`),
 			"array": []hash{{
 				"creditcard": "1234567812345678",
 				"broken":     broken,
@@ -240,6 +242,7 @@ func TestMetaDataSanitize(t *testing.T) {
 			"time":     "2023-12-05T23:59:59.123456789Z",
 			"duration": "29h19m27.462s",
 			"text":     "marshalled text",
+			"json":     `{"hello": "world"}`,
 			"array": []interface{}{map[string]interface{}{
 				"creditcard": "[FILTERED]",
 				"broken": map[string]interface{}{

--- a/v2/metadata_test.go
+++ b/v2/metadata_test.go
@@ -120,6 +120,9 @@ func TestMetadataAddNil(t *testing.T) {
 	var nilMap map[string]interface{}
 	md.AddStruct("nilmap", nilMap)
 
+	var nilSlice []interface{}
+	md.AddStruct("nilSlice", nilSlice)
+
 	var nilError _testError
 	md.AddStruct("error", nilError)
 
@@ -138,6 +141,18 @@ func TestMetadataAddNil(t *testing.T) {
 	var marshalFullPtr = &_textMarshaller{}
 	md.AddStruct("marshalFullPtr", marshalFullPtr)
 
+	var nullJsonMarshaller json.RawMessage
+	md.AddStruct("nullJsonMarshaller", nullJsonMarshaller)
+
+	var fullJsonMarshaller = &json.RawMessage{}
+	md.AddStruct("fullJsonMarshaller", fullJsonMarshaller)
+
+	var nilBytes []byte
+	md.AddStruct("nilBytes", nilBytes)
+
+	var emptyBytes = []byte{}
+	md.AddStruct("emptyBytes", emptyBytes)
+
 	if !reflect.DeepEqual(md, MetaData{
 		"map": {
 			"data": map[string]interface{}{
@@ -146,12 +161,17 @@ func TestMetadataAddNil(t *testing.T) {
 		},
 		"nilmap": map[string]interface{}{},
 		"Extra data": {
-			"error":          "errorstr",
-			"errorNilPtr":    "<nil>",
-			"timeUnset":      "0001-01-01T00:00:00Z",
-			"durationUnset":  "0s",
-			"marshalFullPtr": "marshalled text",
-			"marshalNilPtr":  "<nil>",
+			"nilSlice":           []interface{}{},
+			"error":              "errorstr",
+			"errorNilPtr":        "<nil>",
+			"timeUnset":          "0001-01-01T00:00:00Z",
+			"durationUnset":      "0s",
+			"marshalFullPtr":     "marshalled text",
+			"marshalNilPtr":      "<nil>",
+			"nullJsonMarshaller": "null",
+			"fullJsonMarshaller": "",
+			"nilBytes":           "",
+			"emptyBytes":         "",
 		},
 	}) {
 		t.Errorf("metadata.AddStruct didn't work: %#v", md)

--- a/v2/metadata_test.go
+++ b/v2/metadata_test.go
@@ -113,9 +113,6 @@ func TestMetadataAddPointer(t *testing.T) {
 
 func TestMetadataAddNil(t *testing.T) {
 	md := MetaData{}
-	md.AddStruct("map", map[string]interface{}{
-		"data": _testStruct{Name: nil},
-	})
 
 	var nilMap map[string]interface{}
 	md.AddStruct("nilmap", nilMap)
@@ -144,34 +141,74 @@ func TestMetadataAddNil(t *testing.T) {
 	var nullJsonMarshaller json.RawMessage
 	md.AddStruct("nullJsonMarshaller", nullJsonMarshaller)
 
-	var fullJsonMarshaller = &json.RawMessage{}
-	md.AddStruct("fullJsonMarshaller", fullJsonMarshaller)
+	var nullJsonMarshallerPtr *json.RawMessage
+	md.AddStruct("nullJsonMarshallerPtr", nullJsonMarshallerPtr)
+
+	var emptyJsonMarshaller = &json.RawMessage{}
+	md.AddStruct("emptyJsonMarshaller", emptyJsonMarshaller)
 
 	var nilBytes []byte
 	md.AddStruct("nilBytes", nilBytes)
 
+	var nilBytesPtr *[]byte
+	md.AddStruct("nilBytesPtr", nilBytesPtr)
+
 	var emptyBytes = []byte{}
 	md.AddStruct("emptyBytes", emptyBytes)
+
+	md.AddStruct("map", map[string]interface{}{
+		"data":                  _testStruct{Name: nil},
+		"nilmap":                nilMap,
+		"nilSlice":              nilSlice,
+		"error":                 nilError,
+		"errorNilPtr":           nilErrorPtr,
+		"timeUnset":             timeVar,
+		"durationUnset":         duration,
+		"marshalNilPtr":         marshalNilPtr,
+		"marshalFullPtr":        marshalFullPtr,
+		"nullJsonMarshaller":    nullJsonMarshaller,
+		"nullJsonMarshallerPtr": nullJsonMarshallerPtr,
+		"emptyJsonMarshaller":   emptyJsonMarshaller,
+		"nilBytes":              nilBytes,
+		"nilBytesPtr":           nilBytesPtr,
+		"emptyBytes":            emptyBytes,
+	})
 
 	if !reflect.DeepEqual(md, MetaData{
 		"map": {
 			"data": map[string]interface{}{
 				"Name": "<nil>",
 			},
+			"nilmap":                map[string]interface{}{},
+			"nilSlice":              []interface{}{},
+			"error":                 "errorstr",
+			"errorNilPtr":           "<nil>",
+			"timeUnset":             "0001-01-01T00:00:00Z",
+			"durationUnset":         "0s",
+			"marshalFullPtr":        "marshalled text",
+			"marshalNilPtr":         "<nil>",
+			"nullJsonMarshaller":    "null",
+			"nullJsonMarshallerPtr": "<nil>",
+			"emptyJsonMarshaller":   "",
+			"nilBytes":              "",
+			"nilBytesPtr":           "<nil>",
+			"emptyBytes":            "",
 		},
 		"nilmap": map[string]interface{}{},
 		"Extra data": {
-			"nilSlice":           []interface{}{},
-			"error":              "errorstr",
-			"errorNilPtr":        "<nil>",
-			"timeUnset":          "0001-01-01T00:00:00Z",
-			"durationUnset":      "0s",
-			"marshalFullPtr":     "marshalled text",
-			"marshalNilPtr":      "<nil>",
-			"nullJsonMarshaller": "null",
-			"fullJsonMarshaller": "",
-			"nilBytes":           "",
-			"emptyBytes":         "",
+			"nilSlice":              []interface{}{},
+			"error":                 "errorstr",
+			"errorNilPtr":           "<nil>",
+			"timeUnset":             "0001-01-01T00:00:00Z",
+			"durationUnset":         "0s",
+			"marshalFullPtr":        "marshalled text",
+			"marshalNilPtr":         "<nil>",
+			"nullJsonMarshaller":    "null",
+			"nullJsonMarshallerPtr": "<nil>",
+			"emptyJsonMarshaller":   "",
+			"nilBytes":              "",
+			"nilBytesPtr":           "<nil>",
+			"emptyBytes":            "",
 		},
 	}) {
 		t.Errorf("metadata.AddStruct didn't work: %#v", md)

--- a/v2/metadata_test.go
+++ b/v2/metadata_test.go
@@ -216,7 +216,8 @@ func TestMetaDataSanitize(t *testing.T) {
 			"time":     time.Date(2023, 12, 5, 23, 59, 59, 123456789, time.UTC),
 			"duration": 105567462 * time.Millisecond,
 			"text":     _textMarshaller{},
-			"json":     json.RawMessage(`{"hello": "world"}`),
+			"json":     json.RawMessage(`{"json_property": "json_value"}`),
+			"bytes":    []byte(`lots of bytes`),
 			"array": []hash{{
 				"creditcard": "1234567812345678",
 				"broken":     broken,
@@ -242,7 +243,8 @@ func TestMetaDataSanitize(t *testing.T) {
 			"time":     "2023-12-05T23:59:59.123456789Z",
 			"duration": "29h19m27.462s",
 			"text":     "marshalled text",
-			"json":     `{"hello": "world"}`,
+			"json":     `{"json_property": "json_value"}`,
+			"bytes":    "lots of bytes",
 			"array": []interface{}{map[string]interface{}{
 				"creditcard": "[FILTERED]",
 				"broken": map[string]interface{}{


### PR DESCRIPTION
## Goal
We log in json, and send details and types to both our logger and also to bugsnag that are json.RawMessage, have a MarshalJSON method, or are byte slices.

## Design
Good place for it.

## Changeset
See PR.

## Testing
Added test cases to cover the new functionality.
