### PR TITLE
Update version to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.4.0 (2024-04-15)
+
+### Enhancements
+
+* Sanitize for metadata should also handler json and []byte
+  [#226](https://github.com/bugsnag/bugsnag-go/pull/226)
+  [Chris Duncan](https://github.com/veqryn)
+
 ## 2.3.1 (2024-03-18)
 
 ### Bug fixes

--- a/v2/bugsnag.go
+++ b/v2/bugsnag.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Version defines the version of this Bugsnag notifier
-const Version = "2.3.1"
+const Version = "2.4.0"
 
 var panicHandlerOnce sync.Once
 var sessionTrackerOnce sync.Once


### PR DESCRIPTION
## 2.4.0 (2024-04-14)

### Enhancements

* Sanitize for metadata should also handler json and []byte
  [#226](https://github.com/bugsnag/bugsnag-go/pull/226)
  [Chris Duncan](https://github.com/veqryn)