### PR TITLE
Deliver async reports from a goroutine pool

### DIFF
--- a/v2/configuration.go
+++ b/v2/configuration.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -98,9 +99,19 @@ type Configuration struct {
 	// can be configured if you are in an environment
 	// that has stringent conditions on making http requests.
 	Transport http.RoundTripper
+
 	// Whether bugsnag should notify synchronously. This defaults to false which
 	// causes bugsnag-go to spawn a new goroutine for each notification.
 	Synchronous bool
+
+	// Number of goroutines to use for sending notifications in asynchronous
+	// mode. This defaults to 10.
+	NumGoroutines int
+
+	// The maximum number of reports that can be pending in asynchronous mode.
+	// This defaults to 1000.
+	MaxPendingReports int
+
 	// Whether the notifier should send all sessions recorded so far to Bugsnag
 	// when repanicking to ensure that no session information is lost in a
 	// fatal crash.
@@ -306,6 +317,18 @@ func (config *Configuration) loadEnv() {
 	}
 	if synchronous := os.Getenv("BUGSNAG_SYNCHRONOUS"); synchronous != "" {
 		envConfig.Synchronous = synchronous == "1"
+	}
+	if numGoroutines := os.Getenv("BUGSNAG_NUM_GOROUTINES"); numGoroutines != "" {
+		num, err := strconv.Atoi(numGoroutines)
+		if err != nil {
+			envConfig.NumGoroutines = num
+		}
+	}
+	if maxPendingReports := os.Getenv("BUGSNAG_MAX_PENDING_REPORTS"); maxPendingReports != "" {
+		max, err := strconv.Atoi(maxPendingReports)
+		if err != nil {
+			envConfig.MaxPendingReports = max
+		}
 	}
 	if disablePanics := os.Getenv("BUGSNAG_DISABLE_PANIC_HANDLER"); disablePanics == "1" {
 		envConfig.PanicHandler = func() {}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -3,6 +3,7 @@ module github.com/bugsnag/bugsnag-go/v2
 go 1.15
 
 require (
+	github.com/alitto/pond v1.8.3
 	github.com/bitly/go-simplejson v0.5.1
 	github.com/bugsnag/panicwrap v1.3.4
 	github.com/google/uuid v1.6.0

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,3 +1,5 @@
+github.com/alitto/pond v1.8.3 h1:ydIqygCLVPqIX/USe5EaV/aSRXTRXDEI9JwuDdu+/xs=
+github.com/alitto/pond v1.8.3/go.mod h1:CmvIIGd5jKLasGI3D87qDkQxjzChdKMmnXMg3fG6M6Q=
 github.com/bitly/go-simplejson v0.5.1 h1:xgwPbetQScXt1gh9BmoJ6j9JMr3TElvuIyjR8pgdoow=
 github.com/bitly/go-simplejson v0.5.1/go.mod h1:YOPVLzCfwK14b4Sff3oP1AmGhI9T9Vsg84etUnlyp+Q=
 github.com/bugsnag/panicwrap v1.3.4 h1:A6sXFtDGsgU/4BLf5JT0o5uYg3EeKgGx3Sfs+/uk3pU=

--- a/v2/report_publisher.go
+++ b/v2/report_publisher.go
@@ -17,11 +17,13 @@ func (*defaultReportPublisher) publishReport(p *payload) error {
 		return p.deliver()
 	}
 
-	go func(p *payload) {
+	if !asyncPool.TrySubmit(func() {
 		if err := p.deliver(); err != nil {
 			// Ensure that any errors are logged if they occur in a goroutine.
 			p.logf("bugsnag/defaultReportPublisher.publishReport: %v", err)
 		}
-	}(p)
+	}) {
+		return fmt.Errorf("failed to submit report to async pool")
+	}
 	return nil
 }


### PR DESCRIPTION
## Goal
The goal is to avoid creating a new goroutine for each report when using asynchronous mode. The motivation is that an application that creates more reports than the server can handle, may experience high CPU and memory utilization, which can cause further instability in the application.

This problem has been reported before https://github.com/bugsnag/bugsnag-go/issues/49

<!-- Why is this change necessary? -->

## Design
Allocate a pool of worker goroutines. When asynchronous mode is enabled, `Notify` submits the reports to the pool in a non-blocking fashion. If pool is full, the report will be dropped. This approach maintains the asynchronous behavior while avoiding unlimited proliferation of goroutines.

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->