### PR TITLE
Change async event delivery to single goroutine with events channel queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Limit resource usage while sending events asynchronously \
+  Added MainContext configuration option for providing context from main app
+  [#231](https://github.com/bugsnag/bugsnag-go/pull/231)
+
 ## 2.4.0 (2024-04-15)
 
 ### Enhancements

--- a/LOCAL_TESTING.md
+++ b/LOCAL_TESTING.md
@@ -1,0 +1,29 @@
+
+## Unit tests
+* Install old golang version (do not install just 1.11 - it's not compatible with running newer modules): 
+
+```
+ASDF_GOLANG_OVERWRITE_ARCH=amd64 asdf install golang 1.11.13
+```
+
+* If you see error below use `CGO_ENABLED=0`.
+
+```
+# crypto/x509
+malformed DWARF TagVariable entry
+```
+
+## Local testing with maze runner
+
+* Maze runner tests require
+  * Specyfing `GO_VERSION` env variable to set a golang version for docker container.
+  * Ruby 2.7.
+  * Running docker.
+
+* Commands to run tests
+
+```
+	bundle install
+	bundle exec bugsnag-maze-runner
+  bundle exec bugsnag-maze-runner -c features/<chosen_feature>
+```

--- a/features/fixtures/app/Dockerfile
+++ b/features/fixtures/app/Dockerfile
@@ -1,7 +1,7 @@
 ARG GO_VERSION
 FROM golang:${GO_VERSION}-alpine
 
-RUN apk update && apk upgrade && apk add git bash
+RUN apk update && apk upgrade && apk add git bash build-base
 
 ENV GOPATH /app
 
@@ -28,6 +28,8 @@ WORKDIR /app/src/test
 # Skip on old versions of Go which pre-date modules
 RUN if [[ $GO_VERSION != '1.11' && $GO_VERSION != '1.12' ]]; then \
         go mod init && go mod tidy; \
+        echo "replace github.com/bugsnag/bugsnag-go/v2 => /app/src/github.com/bugsnag/bugsnag-go/v2" >> go.mod; \
+        go mod tidy; \
     fi
 
 RUN chmod +x run.sh

--- a/features/fixtures/app/main.go
+++ b/features/fixtures/app/main.go
@@ -14,12 +14,13 @@ import (
 	bugsnag "github.com/bugsnag/bugsnag-go/v2"
 )
 
-func configureBasicBugsnag(testcase string) {
+func configureBasicBugsnag(testcase string, ctx context.Context) {
 	config := bugsnag.Configuration{
-		APIKey:     os.Getenv("API_KEY"),
-		AppVersion: os.Getenv("APP_VERSION"),
-		AppType:    os.Getenv("APP_TYPE"),
-		Hostname:   os.Getenv("HOSTNAME"),
+		APIKey:      os.Getenv("API_KEY"),
+		AppVersion:  os.Getenv("APP_VERSION"),
+		AppType:     os.Getenv("APP_TYPE"),
+		Hostname:    os.Getenv("HOSTNAME"),
+		MainContext: ctx,
 	}
 
 	if notifyReleaseStages := os.Getenv("NOTIFY_RELEASE_STAGES"); notifyReleaseStages != "" {
@@ -63,11 +64,13 @@ func configureBasicBugsnag(testcase string) {
 }
 
 func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	test := flag.String("test", "handled", "what the app should send, either handled, unhandled, session, autonotify")
 	flag.Parse()
 
-	configureBasicBugsnag(*test)
+	configureBasicBugsnag(*test, ctx)
 	time.Sleep(100 * time.Millisecond) // Ensure tests are less flaky by ensuring the start-up session gets sent
 
 	switch *test {

--- a/features/fixtures/autoconfigure/Dockerfile
+++ b/features/fixtures/autoconfigure/Dockerfile
@@ -1,7 +1,7 @@
 ARG GO_VERSION
 FROM golang:${GO_VERSION}-alpine
 
-RUN apk update && apk upgrade && apk add git bash
+RUN apk update && apk upgrade && apk add git bash build-base
 
 ENV GOPATH /app
 
@@ -28,6 +28,8 @@ WORKDIR /app/src/test
 # Skip on old versions of Go which pre-date modules
 RUN if [[ $GO_VERSION != '1.11' && $GO_VERSION != '1.12' ]]; then \
         go mod init && go mod tidy; \
+        echo "replace github.com/bugsnag/bugsnag-go/v2 => /app/src/github.com/bugsnag/bugsnag-go/v2" >> go.mod; \
+        go mod tidy; \
     fi
 
 RUN chmod +x run.sh

--- a/features/fixtures/net_http/Dockerfile
+++ b/features/fixtures/net_http/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:${GO_VERSION}-alpine
 
 RUN apk update && \
     apk upgrade && \
-    apk add git
+    apk add git build-base
 
 ENV GOPATH /app
 
@@ -30,4 +30,6 @@ WORKDIR /app/src/test
 # Skip on old versions of Go which pre-date modules
 RUN if [[ $GO_VERSION != '1.11' && $GO_VERSION != '1.12' ]]; then \
         go mod init && go mod tidy; \
+        echo "replace github.com/bugsnag/bugsnag-go/v2 => /app/src/github.com/bugsnag/bugsnag-go/v2" >> go.mod; \
+        go mod tidy; \
     fi

--- a/features/fixtures/net_http/main.go
+++ b/features/fixtures/net_http/main.go
@@ -14,7 +14,9 @@ import (
 )
 
 func main() {
-	configureBasicBugsnag()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	configureBasicBugsnag(ctx)
 
 	http.HandleFunc("/handled", handledError)
 	http.HandleFunc("/autonotify-then-recover", unhandledCrash)
@@ -40,16 +42,17 @@ func recoverWrap(h http.Handler) http.Handler {
 	})
 }
 
-func configureBasicBugsnag() {
+func configureBasicBugsnag(ctx context.Context) {
 	config := bugsnag.Configuration{
 		APIKey: os.Getenv("API_KEY"),
 		Endpoints: bugsnag.Endpoints{
 			Notify:   os.Getenv("BUGSNAG_ENDPOINT"),
 			Sessions: os.Getenv("BUGSNAG_ENDPOINT"),
 		},
-		AppVersion: os.Getenv("APP_VERSION"),
-		AppType:    os.Getenv("APP_TYPE"),
-		Hostname:   os.Getenv("HOSTNAME"),
+		AppVersion:  os.Getenv("APP_VERSION"),
+		AppType:     os.Getenv("APP_TYPE"),
+		Hostname:    os.Getenv("HOSTNAME"),
+		MainContext: ctx,
 	}
 
 	if notifyReleaseStages := os.Getenv("NOTIFY_RELEASE_STAGES"); notifyReleaseStages != "" {

--- a/features/handled.feature
+++ b/features/handled.feature
@@ -37,7 +37,7 @@ Scenario: Sending an event using a callback to modify report contents
   And the event "severityReason.type" equals "userCallbackSetSeverity"
   And the event "context" equals "nonfatal.go:14"
   And the "file" of stack frame 0 equals "main.go"
-  And stack frame 0 contains a local function spanning 242 to 248
+  And stack frame 0 contains a local function spanning 245 to 253
   And the "file" of stack frame 1 equals ">insertion<"
   And the "lineNumber" of stack frame 1 equals 0
 
@@ -50,7 +50,7 @@ Scenario: Marking an error as unhandled in a callback
   And the event "severityReason.type" equals "userCallbackSetSeverity"
   And the event "severityReason.unhandledOverridden" is true
   And the "file" of stack frame 0 equals "main.go"
-  And stack frame 0 contains a local function spanning 254 to 257
+  And stack frame 0 contains a local function spanning 257 to 262
 
 Scenario: Unwrapping the causes of a handled error
   When I run the go service "app" with the test case "nested-error"
@@ -59,12 +59,12 @@ Scenario: Unwrapping the causes of a handled error
   And the event "unhandled" is false
   And the event "severity" equals "warning"
   And the event "exceptions.0.message" equals "terminate process"
-  And the "lineNumber" of stack frame 0 equals 292
+  And the "lineNumber" of stack frame 0 equals 295
   And the "file" of stack frame 0 equals "main.go"
   And the "method" of stack frame 0 equals "nestedHandledError"
   And the event "exceptions.1.message" equals "login failed"
   And the event "exceptions.1.stacktrace.0.file" equals "main.go"
-  And the event "exceptions.1.stacktrace.0.lineNumber" equals 312
+  And the event "exceptions.1.stacktrace.0.lineNumber" equals 315
   And the event "exceptions.2.message" equals "invalid token"
   And the event "exceptions.2.stacktrace.0.file" equals "main.go"
-  And the event "exceptions.2.stacktrace.0.lineNumber" equals 320
+  And the event "exceptions.2.stacktrace.0.lineNumber" equals 323

--- a/v2/notifier.go
+++ b/v2/notifier.go
@@ -4,7 +4,7 @@ import (
 	"github.com/bugsnag/bugsnag-go/v2/errors"
 )
 
-var publisher reportPublisher = new(defaultReportPublisher)
+var publisher reportPublisher = newPublisher()
 
 // Notifier sends errors to Bugsnag.
 type Notifier struct {
@@ -84,10 +84,11 @@ func (notifier *Notifier) NotifySync(err error, sync bool, rawData ...interface{
 // AutoNotify notifies Bugsnag of any panics, then repanics.
 // It sends along any rawData that gets passed in.
 // Usage:
-//  go func() {
-//		defer AutoNotify()
-//      // (possibly crashy code)
-//  }()
+//
+//	 go func() {
+//			defer AutoNotify()
+//	     // (possibly crashy code)
+//	 }()
 func (notifier *Notifier) AutoNotify(rawData ...interface{}) {
 	if err := recover(); err != nil {
 		severity := notifier.getDefaultSeverity(rawData, SeverityError)

--- a/v2/report_publisher.go
+++ b/v2/report_publisher.go
@@ -1,14 +1,74 @@
 package bugsnag
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
 
 type reportPublisher interface {
 	publishReport(*payload) error
+	setMainProgramContext(context.Context)
 }
 
-type defaultReportPublisher struct{}
+func (defPub *defaultReportPublisher) delivery() {
+	signalsCh := make(chan os.Signal, 1)
+	signal.Notify(signalsCh, syscall.SIGINT, syscall.SIGTERM)
 
-func (*defaultReportPublisher) publishReport(p *payload) error {
+waitForEnd:
+	for {
+		select {
+		case <-signalsCh:
+			defPub.isClosing = true
+			break waitForEnd
+		case <-defPub.mainProgramCtx.Done():
+			defPub.isClosing = true
+			break waitForEnd
+		case p, ok := <-defPub.eventsChan:
+			if ok {
+				if err := p.deliver(); err != nil {
+					// Ensure that any errors are logged if they occur in a goroutine.
+					p.logf("bugsnag/defaultReportPublisher.publishReport: %v", err)
+				}
+			} else {
+				p.logf("Event channel closed")
+				return
+			}
+		}
+	}
+
+	// Send remaining elements from the queue
+	close(defPub.eventsChan)
+	for p := range defPub.eventsChan {
+			if err := p.deliver(); err != nil {
+				// Ensure that any errors are logged if they occur in a goroutine.
+				p.logf("bugsnag/defaultReportPublisher.publishReport: %v", err)
+			}
+	}
+}
+
+type defaultReportPublisher struct {
+	eventsChan     chan *payload
+	mainProgramCtx context.Context
+	isClosing      bool
+}
+
+func newPublisher() reportPublisher {
+	defPub := defaultReportPublisher{isClosing: false, mainProgramCtx: context.TODO()}
+	defPub.eventsChan = make(chan *payload, 100)
+
+	go defPub.delivery()
+
+	return &defPub
+}
+
+func (defPub *defaultReportPublisher) setMainProgramContext(ctx context.Context) {
+	defPub.mainProgramCtx = ctx
+}
+
+func (defPub *defaultReportPublisher) publishReport(p *payload) error {
 	p.logf("notifying bugsnag: %s", p.Message)
 	if !p.notifyInReleaseStage() {
 		return fmt.Errorf("not notifying in %s", p.ReleaseStage)
@@ -17,11 +77,15 @@ func (*defaultReportPublisher) publishReport(p *payload) error {
 		return p.deliver()
 	}
 
-	go func(p *payload) {
-		if err := p.deliver(); err != nil {
-			// Ensure that any errors are logged if they occur in a goroutine.
-			p.logf("bugsnag/defaultReportPublisher.publishReport: %v", err)
-		}
-	}(p)
+	if defPub.isClosing {
+		return fmt.Errorf("main program is stopping, new events won't be sent")
+	}
+
+	select {
+	case defPub.eventsChan <- p:
+	default:
+		p.logf("Events channel full. Discarding value")
+	}
+
 	return nil
 }


### PR DESCRIPTION
## Goal
In case of heavy load notifier created too many goroutines for sending events thus consuming a lot of resources.
Adding a single goroutine with a channel will limit usage of resources and allow events to get queued to be sent instead of trying to send everything at once.

## Changeset
Added a single goroutine as a default strategy for the async delivery. On failure events are dropped.
Goroutine has two ways of handling graceful shutdown. Either react to a signal which it's registered to or react to main program context sending `Done()`.
Added configuration option for passing MainProgramContext.

## Testing
Existing maze-runner tests can be used