### PR TITLE
Pin tests to Ubuntu 20.04

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -5,14 +5,14 @@ on: [ push, pull_request ]
 jobs:
   test:
 
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: 'go/src/github.com/bugsnag/bugsnag-go/v2' # relative to $GITHUB_WORKSPACE
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, windows]
+        os: [ubuntu-20.04, windows-latest]
         go-version: ['1.11', '1.12', '1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22']
 
     steps:


### PR DESCRIPTION
## Goal

Pin tests to Ubuntu 20.04.

## Design

GitHub Actions recently updated `ubuntu-latest` to 22.04, which for some reason breaks the fixture build.  This PR gets us moving again while we look into that.

## Testing

Covered by CI.