### PR TITLE
Ensure maze runner tests run on the CI

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -20,11 +20,11 @@ jobs:
       with:
         path: 'go/src/github.com/bugsnag/bugsnag-go' # relative to $GITHUB_WORKSPACE
     - name: set GOPATH
-      if: matrix.os == 'ubuntu'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         bash -c 'echo "GOPATH=$GITHUB_WORKSPACE/go" >> $GITHUB_ENV'
     - name: set GOPATH
-      if: matrix.os == 'windows'
+      if: matrix.os == 'windows-latest'
       run: |
         bash -c 'echo "GOPATH=$GITHUB_WORKSPACE\\\\go" >> $GITHUB_ENV'
     - uses: actions/setup-go@v2
@@ -40,18 +40,18 @@ jobs:
       run: go vet ./...
 
     - name: install Ruby
-      if: matrix.os == 'ubuntu'
+      if: matrix.os == 'ubuntu-20.04'
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
         bundler-cache: true
         working-directory: go/src/github.com/bugsnag/bugsnag-go # relative to $GITHUB_WORKSPACE
     - name: install integration dependencies
-      if: matrix.os == 'ubuntu'
+      if: matrix.os == 'ubuntu-20.04'
       run: sudo apt-get install docker-compose
     - name: maze tests
       working-directory: go/src/github.com/bugsnag/bugsnag-go
-      if: matrix.os == 'ubuntu'
+      if: matrix.os == 'ubuntu-20.04'
       env:
         GO_VERSION: ${{ matrix.go-version }}
       run: bundle exec bugsnag-maze-runner --color --format progress


### PR DESCRIPTION
## Goal

In #235 the maze runner tests where accidentally disabled because of a change in the OS names. This MR updates references to matrix.os to match the changed names, allowing the maze runner tests to run again.

It would appear that downgrading Ubuntu has not really helped the test pass rate.