### PR TITLE
Add integrity header, change to command pattern in test app

### DIFF
--- a/features/fixtures/app/Dockerfile
+++ b/features/fixtures/app/Dockerfile
@@ -4,8 +4,10 @@ FROM golang:${GO_VERSION}-alpine
 RUN apk update && apk upgrade && apk add git bash build-base
 
 ENV GOPATH /app
+ENV GO111MODULE="on"
 
-COPY testbuild /app/src/github.com/bugsnag/bugsnag-go
+COPY features /app/src/features
+COPY v2 /app/src/github.com/bugsnag/bugsnag-go/v2
 WORKDIR /app/src/github.com/bugsnag/bugsnag-go/v2
 
 # Ensure subsequent steps are re-run if the GO_VERSION variable changes
@@ -20,17 +22,13 @@ RUN if [[ $(echo -e "1.11\n$GO_VERSION\n1.16" | sort -V | head -2 | tail -1) == 
         go install ./...; \
     fi
 
-# Copy test scenarios
-COPY ./app /app/src/test
-WORKDIR /app/src/test
+WORKDIR /app/src/features/fixtures/app
 
 # Create app module - avoid locking bugsnag dep by not checking it in
 # Skip on old versions of Go which pre-date modules
-RUN if [[ $GO_VERSION != '1.11' && $GO_VERSION != '1.12' ]]; then \
-        go mod init && go mod tidy; \
-        echo "replace github.com/bugsnag/bugsnag-go/v2 => /app/src/github.com/bugsnag/bugsnag-go/v2" >> go.mod; \
-        go mod tidy; \
-    fi
+RUN     go mod init && go mod tidy && \
+        echo "replace github.com/bugsnag/bugsnag-go/v2 => /app/src/github.com/bugsnag/bugsnag-go/v2" >> go.mod && \
+        go mod tidy
 
 RUN chmod +x run.sh
-CMD ["/app/src/test/run.sh"]
+CMD ["/app/src/features/fixtures/app/run.sh"]

--- a/features/fixtures/app/command.go
+++ b/features/fixtures/app/command.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const DEFAULT_MAZE_ADDRESS = "http://localhost:9339"
+
+type Command struct {
+	Action           string `json:"action,omitempty"`
+	ScenarioName     string `json:"scenario_name,omitempty"`
+	APIKey           string `json:"api_key,omitempty"`
+	NotifyEndpoint   string `json:"notify_endpoint,omitempty"`
+	SessionsEndpoint string `json:"sessions_endpoint,omitempty"`
+	UUID             string `json:"uuid,omitempty"`
+	RunUUID          string `json:"run_uuid,omitempty"`
+}
+
+func GetCommand(mazeAddress string) Command {
+	var command Command
+	mazeURL := fmt.Sprintf("%+v/command", mazeAddress)
+	client := http.Client{Timeout: 2 * time.Second}
+	res, err := client.Get(mazeURL)
+	if err != nil {
+		fmt.Printf("[Bugsnag] Error while receiving command: %+v\n", err)
+		return command
+	}
+
+	if res != nil {
+		err = json.NewDecoder(res.Body).Decode(&command)
+		res.Body.Close()
+		if err != nil {
+			fmt.Printf("[Bugsnag] Error while decoding command: %+v\n", err)
+			return command
+		}
+	}
+
+	return command
+}

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -1,12 +1,12 @@
-version: '3.4'
 services:
   app:
     build:
-      context: .
-      dockerfile: app/Dockerfile
+      context: ../../
+      dockerfile: ./features/fixtures/app/Dockerfile
       args:
        - GO_VERSION
     environment:
+      - DEFAULT_MAZE_ADDRESS
       - API_KEY
       - ERROR_CLASS
       - BUGSNAG_ENDPOINT

--- a/features/steps/go_steps.rb
+++ b/features/steps/go_steps.rb
@@ -1,4 +1,45 @@
 require 'net/http'
+require 'os'
+
+When('I run {string}') do |scenario_name|
+  execute_command 'run-scenario', scenario_name
+end
+
+When('I configure the base endpoint') do
+  steps %(
+    When I set environment variable "DEFAULT_MAZE_ADDRESS" to "http://#{local_ip}:9339"
+  )
+end
+
+def execute_command(action, scenario_name = '')
+    address = $address ? $address : "#{local_ip}:9339"
+
+  command = {
+    action: action,
+    scenario_name: scenario_name,
+    notify_endpoint: "http://#{address}/notify",
+    sessions_endpoint: "http://#{address}/sessions",
+    api_key: $api_key,
+  }
+
+  $logger.debug("Queuing command: #{command}")
+  Maze::Server.commands.add command
+
+  # Ensure fixture has read the command
+  count = 900
+  sleep 0.1 until Maze::Server.commands.remaining.empty? || (count -= 1) < 1
+  raise 'Test fixture did not GET /command' unless Maze::Server.commands.remaining.empty?
+end
+
+def local_ip
+  if OS.mac?
+    'host.docker.internal'
+  else
+    ip_addr = `ifconfig | grep -Eo 'inet (addr:)?([0-9]*\\\.){3}[0-9]*' | grep -v '127.0.0.1'`
+    ip_list = /((?:[0-9]*\.){3}[0-9]*)/.match(ip_addr)
+    ip_list.captures.first
+  end
+end
 
 Given("I set environment variable {string} to the app directory") do |key|
   step("I set environment variable \"#{key}\" to \"/app/src/test/\"")

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,16 +1,7 @@
-require 'fileutils'
-require 'socket'
-require 'timeout'
-
-testBuildFolder = 'features/fixtures/testbuild'
-
-FileUtils.rm_rf(testBuildFolder)
-Dir.mkdir testBuildFolder
-
-# Copy the existing dir
-`find . -name '*.go' -o -name 'go.sum' -o -name 'go.mod' \
-        -not -path "./examples/*" \
-        -not -path "./testutil/*" \
-        -not -path "./v2/testutil/*" \
-        -not -path "./features/*" \
-        -not -name '*_test.go' | cpio -pdm #{testBuildFolder}`
+Before do
+        $address = nil
+        $api_key = "166f5ad3590596f9aa8d601ea89af845"
+        steps %(
+          When I configure the base endpoint
+        )
+      end

--- a/v2/headers/prefixed.go
+++ b/v2/headers/prefixed.go
@@ -1,14 +1,20 @@
 package headers
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
-//PrefixedHeaders returns a map of Content-Type and the 'Bugsnag-' headers for
-//API key, payload version, and the time at which the request is being sent.
-func PrefixedHeaders(apiKey, payloadVersion string) map[string]string {
+// PrefixedHeaders returns a map of Content-Type and the 'Bugsnag-' headers for
+// API key, payload version, and the time at which the request is being sent.
+func PrefixedHeaders(apiKey, payloadVersion, sha1 string) map[string]string {
+	integrityHeader := fmt.Sprintf("sha1 %v", sha1)
+
 	return map[string]string{
 		"Content-Type":            "application/json",
 		"Bugsnag-Api-Key":         apiKey,
 		"Bugsnag-Payload-Version": payloadVersion,
 		"Bugsnag-Sent-At":         time.Now().UTC().Format(time.RFC3339),
+		"Bugsnag-Integrity":       integrityHeader,
 	}
 }

--- a/v2/headers/prefixed_test.go
+++ b/v2/headers/prefixed_test.go
@@ -1,6 +1,7 @@
 package headers
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -8,9 +9,10 @@ import (
 
 const APIKey = "abcd1234abcd1234"
 const testPayloadVersion = "3"
+const testSHA = "5e13ae4640ae4ae0e09c05b7bb060f544dabd042"
 
 func TestConstantBugsnagPrefixedHeaders(t *testing.T) {
-	headers := PrefixedHeaders(APIKey, testPayloadVersion)
+	headers := PrefixedHeaders(APIKey, testPayloadVersion, testSHA)
 	testCases := []struct {
 		header   string
 		expected string
@@ -18,6 +20,7 @@ func TestConstantBugsnagPrefixedHeaders(t *testing.T) {
 		{header: "Content-Type", expected: "application/json"},
 		{header: "Bugsnag-Api-Key", expected: APIKey},
 		{header: "Bugsnag-Payload-Version", expected: testPayloadVersion},
+		{header: "Bugsnag-Integrity", expected: fmt.Sprintf("sha1 %v", testSHA)},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.header, func(st *testing.T) {
@@ -29,7 +32,7 @@ func TestConstantBugsnagPrefixedHeaders(t *testing.T) {
 }
 
 func TestTimeDependentBugsnagPrefixedHeaders(t *testing.T) {
-	headers := PrefixedHeaders(APIKey, testPayloadVersion)
+	headers := PrefixedHeaders(APIKey, testPayloadVersion, testSHA)
 	sentAtString := headers["Bugsnag-Sent-At"]
 	if !strings.HasSuffix(sentAtString, "Z") {
 		t.Errorf("Error when setting Bugsnag-Sent-At header: %s, doesn't end with a Z", sentAtString)


### PR DESCRIPTION
Prepared test app's command pattern.
Integrity header added to event and session payload.
In test app main file I've left "scenario"-like functions - they will be changed in the next PR.