### PR TITLE
Remove Bugsnag-Integrity header

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,7 +1,8 @@
 Before do
-        $address = nil
-        $api_key = "166f5ad3590596f9aa8d601ea89af845"
-        steps %(
-          When I configure the base endpoint
-        )
-      end
+  Maze.config.enforce_bugsnag_integrity = false
+  $address = nil
+  $api_key = "166f5ad3590596f9aa8d601ea89af845"
+  steps %(
+    When I configure the base endpoint
+  )
+end

--- a/v2/headers/prefixed.go
+++ b/v2/headers/prefixed.go
@@ -1,20 +1,16 @@
 package headers
 
 import (
-	"fmt"
 	"time"
 )
 
 // PrefixedHeaders returns a map of Content-Type and the 'Bugsnag-' headers for
 // API key, payload version, and the time at which the request is being sent.
-func PrefixedHeaders(apiKey, payloadVersion, sha1 string) map[string]string {
-	integrityHeader := fmt.Sprintf("sha1 %v", sha1)
-
+func PrefixedHeaders(apiKey, payloadVersion string) map[string]string {
 	return map[string]string{
 		"Content-Type":            "application/json",
 		"Bugsnag-Api-Key":         apiKey,
 		"Bugsnag-Payload-Version": payloadVersion,
 		"Bugsnag-Sent-At":         time.Now().UTC().Format(time.RFC3339),
-		"Bugsnag-Integrity":       integrityHeader,
 	}
 }

--- a/v2/headers/prefixed_test.go
+++ b/v2/headers/prefixed_test.go
@@ -1,7 +1,6 @@
 package headers
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -9,10 +8,9 @@ import (
 
 const APIKey = "abcd1234abcd1234"
 const testPayloadVersion = "3"
-const testSHA = "5e13ae4640ae4ae0e09c05b7bb060f544dabd042"
 
 func TestConstantBugsnagPrefixedHeaders(t *testing.T) {
-	headers := PrefixedHeaders(APIKey, testPayloadVersion, testSHA)
+	headers := PrefixedHeaders(APIKey, testPayloadVersion)
 	testCases := []struct {
 		header   string
 		expected string
@@ -20,7 +18,6 @@ func TestConstantBugsnagPrefixedHeaders(t *testing.T) {
 		{header: "Content-Type", expected: "application/json"},
 		{header: "Bugsnag-Api-Key", expected: APIKey},
 		{header: "Bugsnag-Payload-Version", expected: testPayloadVersion},
-		{header: "Bugsnag-Integrity", expected: fmt.Sprintf("sha1 %v", testSHA)},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.header, func(st *testing.T) {
@@ -32,7 +29,7 @@ func TestConstantBugsnagPrefixedHeaders(t *testing.T) {
 }
 
 func TestTimeDependentBugsnagPrefixedHeaders(t *testing.T) {
-	headers := PrefixedHeaders(APIKey, testPayloadVersion, testSHA)
+	headers := PrefixedHeaders(APIKey, testPayloadVersion)
 	sentAtString := headers["Bugsnag-Sent-At"]
 	if !strings.HasSuffix(sentAtString, "Z") {
 		t.Errorf("Error when setting Bugsnag-Sent-At header: %s, doesn't end with a Z", sentAtString)

--- a/v2/payload.go
+++ b/v2/payload.go
@@ -2,8 +2,6 @@ package bugsnag
 
 import (
 	"bytes"
-	"crypto/sha1"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -38,13 +36,6 @@ func (p *payload) deliver() error {
 		return fmt.Errorf("bugsnag/payload.deliver: %v", err)
 	}
 
-	hasher := sha1.New()
-	_, err = hasher.Write(buf)
-	if err != nil {
-		return fmt.Errorf("bugsnag/payload.deliver: %v", err)
-	}
-	sha1_hash := hex.EncodeToString(hasher.Sum(nil))
-
 	client := http.Client{
 		Transport: p.Transport,
 	}
@@ -52,7 +43,7 @@ func (p *payload) deliver() error {
 	if err != nil {
 		return fmt.Errorf("bugsnag/payload.deliver unable to create request: %v", err)
 	}
-	for k, v := range headers.PrefixedHeaders(p.APIKey, notifyPayloadVersion, sha1_hash) {
+	for k, v := range headers.PrefixedHeaders(p.APIKey, notifyPayloadVersion) {
 		req.Header.Add(k, v)
 	}
 	resp, err := client.Do(req)

--- a/v2/sessions/publisher.go
+++ b/v2/sessions/publisher.go
@@ -2,8 +2,6 @@ package sessions
 
 import (
 	"bytes"
-	"crypto/sha1"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -63,19 +61,12 @@ func (p *publisher) publish(sessions []*Session) error {
 		return fmt.Errorf("bugsnag/sessions/publisher.publish unable to marshal json: %v", err)
 	}
 
-	hasher := sha1.New()
-	_, err = hasher.Write(buf)
-	if err != nil {
-		return fmt.Errorf("bugsnag/payload.deliver: %v", err)
-	}
-	sha1_hash := hex.EncodeToString(hasher.Sum(nil))
-
 	req, err := http.NewRequest("POST", p.config.Endpoint, bytes.NewBuffer(buf))
 	if err != nil {
 		return fmt.Errorf("bugsnag/sessions/publisher.publish unable to create request: %v", err)
 	}
 
-	for k, v := range headers.PrefixedHeaders(p.config.APIKey, sessionPayloadVersion, sha1_hash) {
+	for k, v := range headers.PrefixedHeaders(p.config.APIKey, sessionPayloadVersion) {
 		req.Header.Add(k, v)
 	}
 


### PR DESCRIPTION
Server side notifiers don't have to support Bugsnag-Integrity header.
Disabled the check from maze-runner side.