### PR TITLE
Move start of delivery goroutine to configure, don't wait on signals in delivery

### DIFF
--- a/v2/bugsnag.go
+++ b/v2/bugsnag.go
@@ -48,6 +48,9 @@ func Configure(config Configuration) {
 	readEnvConfigOnce.Do(Config.loadEnv)
 	Config.update(&config)
 	updateSessionConfig()
+
+	// start delivery goroutine later than the module import time
+	go publisher.delivery()
 	// Only do once in case the user overrides the default panichandler, and
 	// configures multiple times.
 	panicHandlerOnce.Do(Config.PanicHandler)

--- a/v2/bugsnag_test.go
+++ b/v2/bugsnag_test.go
@@ -151,6 +151,9 @@ func (tp *testPublisher) publishReport(p *payload) error {
 func (tp *testPublisher) setMainProgramContext(context.Context) {
 }
 
+func (tp *testPublisher) delivery() {
+}
+
 func TestNotifySyncThenAsync(t *testing.T) {
 	ts, _ := setup()
 	defer ts.Close()


### PR DESCRIPTION
## Goal
Customers reported that delivery goroutine that starts as soon as module is loading is appearing as a leak in the diagnostic tools such as `goleak`. It can be safely moved to `Configure` method.
In the delivery goroutine we were also subscribing to os signals as a way to provide graceful shutdown. Unfortunately that led to main program being unable to capture signals. So our `signal.Notify` usage has to be removed.

Fixes issues:
- https://github.com/bugsnag/bugsnag-go/issues/247
- https://github.com/bugsnag/bugsnag-go/issues/249

## Changeset
Removed `signal.Notify` usage in delivery goroutine.
Moved starting delivery goroutine to `Configure` method.

## Testing
Tested using code snippets provided in issues.