### PR TITLE
Update version to 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.5.1 (2024-10-21)
+
+### Bug fixes
+
+* Move start of delivery goroutine to configure, don't wait on signals in delivery
+  [#250](https://github.com/bugsnag/bugsnag-go/pull/250)
+
 ## 2.5.0 (2024-08-27)
 
 ### Enhancements

--- a/v2/bugsnag.go
+++ b/v2/bugsnag.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Version defines the version of this Bugsnag notifier
-const Version = "2.5.0"
+const Version = "2.5.1"
 
 var panicHandlerOnce sync.Once
 var sessionTrackerOnce sync.Once


### PR DESCRIPTION
## 2.5.1 (2024-10-21)

### Bug fixes

* Move start of delivery goroutine to configure, don't wait on signals in delivery
  [#250](https://github.com/bugsnag/bugsnag-go/pull/250)