### PR TITLE
Set default endpoints based on API key

### DIFF
--- a/v2/configuration.go
+++ b/v2/configuration.go
@@ -10,6 +10,12 @@ import (
 	"strings"
 )
 
+const (
+	HUB_PREFIX = "00000"
+	HUB_NOTIFY = "https://notify.insighthub.smartbear.com"
+	HUB_SESSION = "https://sessions.insighthub.smartbear.com"
+)
+
 // Endpoints hold the HTTP endpoints of the notifier.
 type Endpoints struct {
 	Sessions string
@@ -221,6 +227,11 @@ func (config *Configuration) updateEndpoints(endpoints *Endpoints) {
 			panic("FATAL: Bugsnag sessions endpoint configured without also changing the notify endpoint. Bugsnag cannot identify where to report errors")
 		}
 		config.Endpoints.Sessions = endpoints.Sessions
+	}
+
+	if strings.HasPrefix(config.APIKey, HUB_PREFIX) && endpoints.Notify == "" && endpoints.Sessions == "" {
+		config.Endpoints.Notify = HUB_NOTIFY
+		config.Endpoints.Sessions = HUB_SESSION
 	}
 }
 

--- a/v2/configuration_test.go
+++ b/v2/configuration_test.go
@@ -378,3 +378,55 @@ func TestIsAutoCaptureSessions(t *testing.T) {
 		t.Errorf("Expected automatic session tracking to be disabled when so configured, but enabled")
 	}
 }
+
+func TestInsightHubEndpoints(t *testing.T) {
+	defaultNotify := "https://notify.bugsnag.com/"
+	defaultSessions := "https://sessions.bugsnag.com/"
+	hubNotify := "https://notify.insighthub.smartbear.com"
+	hubSession := "https://sessions.insighthub.smartbear.com"
+	hubApiKey := "00000abcdef0123456789abcdef012345"
+
+	testConfig := Configuration{
+		Endpoints: Endpoints{
+			Notify:   defaultNotify,
+			Sessions: defaultSessions,
+		},
+	}
+
+	testConfig.update(&Configuration{
+			APIKey: hubApiKey,
+	})
+
+	if testConfig.Endpoints.Notify != hubNotify {
+		t.Errorf("Expected Notify endpoint to be '%s' but was '%s'", hubNotify, testConfig.Endpoints.Notify)
+	}
+	if testConfig.Endpoints.Sessions != hubSession {
+		t.Errorf("Expected Sessions endpoint to be '%s' but was '%s'", hubSession, testConfig.Endpoints.Sessions)
+	}
+}
+
+func TestInsightHubEndpointsWithCustomEndpoints(t *testing.T) {
+	defaultNotify := "https://notify.bugsnag.com/"
+	defaultSessions := "https://sessions.bugsnag.com/"
+	hubApiKey := "00000abcdef0123456789abcdef012345"
+
+	testConfig := Configuration{
+		Endpoints: Endpoints{
+			Notify:   defaultNotify,
+			Sessions: defaultSessions,
+		},
+	}
+	testConfig.update(&Configuration{
+		APIKey: hubApiKey,
+		Endpoints: Endpoints{
+			Notify:   "https://custom.notify.com/",
+			Sessions: "https://custom.sessions.com/",
+		},
+	})
+	if testConfig.Endpoints.Notify != "https://custom.notify.com/" {
+		t.Errorf("Expected Notify endpoint to be '%s' but was '%s'", "https://custom.notify.com/", testConfig.Endpoints.Notify)
+	}
+	if testConfig.Endpoints.Sessions != "https://custom.sessions.com/" {
+		t.Errorf("Expected Sessions endpoint to be '%s' but was '%s'", "https://custom.sessions.com/", testConfig.Endpoints.Sessions)
+	}
+}


### PR DESCRIPTION
## Goal
Set default endpoints based on API key. If no custom endpoint is configured, payloads should be sent to *.insighthub.smartbear.com if the API key starts with 00000.

## Testing
Unit tests added.