### PR TITLE
Update version to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## 2.6.0 (2025-07-10)
 
 ### Enhancements
 

--- a/v2/bugsnag.go
+++ b/v2/bugsnag.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Version defines the version of this Bugsnag notifier
-const Version = "2.5.1"
+const Version = "2.6.0"
 
 var panicHandlerOnce sync.Once
 var sessionTrackerOnce sync.Once


### PR DESCRIPTION
## 2.6.0 (2025-07-10)

### Enhancements

* Set default endpoints based on API key [#259](https://github.com/bugsnag/bugsnag-go/pull/259)