### PR TITLE
Handle endpoints being set only in env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Handle endpoints being set only in env vars [#262](https://github.com/bugsnag/bugsnag-go/pull/262)
+
 ## 2.6.0 (2025-07-10)
 
 ### Enhancements

--- a/v2/configuration.go
+++ b/v2/configuration.go
@@ -218,6 +218,8 @@ func (config *Configuration) IsAutoCaptureSessions() bool {
 
 func (config *Configuration) updateEndpoints(endpoints *Endpoints) {
 	sessionsDisabled := false
+
+	// custom endpoint provided
 	if endpoints.Notify != "" {
 		config.Endpoints.Notify = endpoints.Notify
 		if endpoints.Sessions == "" {
@@ -226,25 +228,36 @@ func (config *Configuration) updateEndpoints(endpoints *Endpoints) {
 			sessionsDisabled = true
 		}
 	} else {
-		if strings.HasPrefix(config.APIKey, HUB_PREFIX) {
-			config.Endpoints.Notify = HUB_NOTIFY
-		} else {
-			config.Endpoints.Notify = DEFAULT_NOTIFY
+		// no custom endpoint provided, use defaults
+		if config.Endpoints.Notify == "" {
+			// notify endpoint not set, calculate default based on API key
+			if strings.HasPrefix(config.APIKey, HUB_PREFIX) {
+				config.Endpoints.Notify = HUB_NOTIFY
+			} else {
+				config.Endpoints.Notify = DEFAULT_NOTIFY
+			}
 		}
+		// notify endpoint already set, do not override it
 	}
 
+	// custom sessions endpoint provided
 	if endpoints.Sessions != "" {
 		if endpoints.Notify == "" {
 			panic("FATAL: Bugsnag sessions endpoint configured without also changing the notify endpoint. Bugsnag cannot identify where to report errors")
 		}
 		config.Endpoints.Sessions = endpoints.Sessions
 	} else {
+		// no custom sessions endpoint provided, use defaults
 		if !sessionsDisabled {
-			if strings.HasPrefix(config.APIKey, HUB_PREFIX) {
-				config.Endpoints.Sessions = HUB_SESSION
-			} else {
-				config.Endpoints.Sessions = DEFAULT_SESSIONS
+			if config.Endpoints.Sessions == "" {
+				// sessions endpoint not set, calculate default based on API key
+				if strings.HasPrefix(config.APIKey, HUB_PREFIX) {
+					config.Endpoints.Sessions = HUB_SESSION
+				} else {
+					config.Endpoints.Sessions = DEFAULT_SESSIONS
+				}
 			}
+			// sessions endpoint already set, do not override it
 		}
 	}
 }


### PR DESCRIPTION
## Goal
If user provided Endpoints configuration only by Environment variables in the current solution they would still be overwritten by defaults.

## Changeset
If the endpoint value is already set and the next config does not specify it - then do not update the value with default.

## Testing
Added unit tests that set environment variables.