### PR TITLE
Amend default secondary instance URL to bugsnag.smartbear.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,16 +71,11 @@ If you are a project maintainer, you can build and release a new version of
 **Prerequisite**: All code changes should already have been reviewed and PR'd into the `next` branch before making a release.
 
 1. Decide on a version number and date for this release
-1. Add an entry (or update the `TBD` entry if it exists) for this release in `CHANGELOG.md` so that it includes the version number, release date and granular description of what changed
-1. Update the README if necessary
-1. Update the version number in `v2/bugsnag.go` and verify that tests pass.
-1. Commit these changes `git commit -am "Preparing release"`
-1. Create a PR from `next` -> `master` titled `Release vX.X.X`, adding a description to help the reviewer understand the scope of the release
-1. Await PR approval and CI pass
-1. Merge to master on GitHub, using the UI to set the merge commit message to be `vX.X.X`
-1. Create a release from current `master` on GitHub called `vX.X.X`. Copy and paste the markdown from this release's notes in `CHANGELOG.md` (this will create a git tag for you).
-1. Ensure setup guides for Go (and its frameworks) on docs.bugsnag.com are correct and up to date.
-1. Merge `master` into `next` (since we just did a merge commit the other way, this will be a fastforward update) and push it so that it is ready for future PRs.
+2. Add an entry (or update the `TBD` entry if it exists) for this release in `CHANGELOG.md` so that it includes the version number, release date and granular description of what changed
+3. Update the version number in `v2/bugsnag.go` and verify that tests pass.
+4. Create a PR from `release-x.x.x-next` -> `next` titled `Release vX.X.X`, adding a description to help the reviewer understand the scope of the release
+5. Create a PR from `next` to `master` on GitHub, set the commit message to `vX.X.X`
+6. Create a release from current `master` on GitHub called `vX.X.X`. Copy and paste the markdown from this release's notes in `CHANGELOG.md` (this will create a git tag for you).
 
 
 #### Hotfixes

--- a/v2/configuration.go
+++ b/v2/configuration.go
@@ -11,11 +11,11 @@ import (
 )
 
 const (
-	HUB_PREFIX       = "00000"
-	HUB_NOTIFY       = "https://notify.bugsnag.smartbear.com"
-	HUB_SESSION      = "https://sessions.bugsnag.smartbear.com"
-	DEFAULT_NOTIFY   = "https://notify.bugsnag.com"
-	DEFAULT_SESSIONS = "https://sessions.bugsnag.com"
+	SECONDARY_ENDPOINT_PREFIX = "00000"
+	SECONDARY_NOTIFY          = "https://notify.bugsnag.smartbear.com"
+	SECONDARY_SESSION         = "https://sessions.bugsnag.smartbear.com"
+	DEFAULT_NOTIFY            = "https://notify.bugsnag.com"
+	DEFAULT_SESSIONS          = "https://sessions.bugsnag.com"
 )
 
 // Endpoints hold the HTTP endpoints of the notifier.
@@ -231,8 +231,8 @@ func (config *Configuration) updateEndpoints(endpoints *Endpoints) {
 		// no custom endpoint provided, use defaults
 		if config.Endpoints.Notify == "" {
 			// notify endpoint not set, calculate default based on API key
-			if strings.HasPrefix(config.APIKey, HUB_PREFIX) {
-				config.Endpoints.Notify = HUB_NOTIFY
+			if strings.HasPrefix(config.APIKey, SECONDARY_ENDPOINT_PREFIX) {
+				config.Endpoints.Notify = SECONDARY_NOTIFY
 			} else {
 				config.Endpoints.Notify = DEFAULT_NOTIFY
 			}
@@ -251,8 +251,8 @@ func (config *Configuration) updateEndpoints(endpoints *Endpoints) {
 		if !sessionsDisabled {
 			if config.Endpoints.Sessions == "" {
 				// sessions endpoint not set, calculate default based on API key
-				if strings.HasPrefix(config.APIKey, HUB_PREFIX) {
-					config.Endpoints.Sessions = HUB_SESSION
+				if strings.HasPrefix(config.APIKey, SECONDARY_ENDPOINT_PREFIX) {
+					config.Endpoints.Sessions = SECONDARY_SESSION
 				} else {
 					config.Endpoints.Sessions = DEFAULT_SESSIONS
 				}

--- a/v2/configuration.go
+++ b/v2/configuration.go
@@ -12,8 +12,8 @@ import (
 
 const (
 	HUB_PREFIX       = "00000"
-	HUB_NOTIFY       = "https://notify.insighthub.smartbear.com"
-	HUB_SESSION      = "https://sessions.insighthub.smartbear.com"
+	HUB_NOTIFY       = "https://notify.bugsnag.smartbear.com"
+	HUB_SESSION      = "https://sessions.bugsnag.smartbear.com"
 	DEFAULT_NOTIFY   = "https://notify.bugsnag.com"
 	DEFAULT_SESSIONS = "https://sessions.bugsnag.com"
 )

--- a/v2/configuration_test.go
+++ b/v2/configuration_test.go
@@ -443,9 +443,9 @@ func TestIsAutoCaptureSessions(t *testing.T) {
 	}
 }
 
-func TestInsightHubEndpoints(t *testing.T) {
-	hubNotify := "https://notify.insighthub.smartbear.com"
-	hubSession := "https://sessions.insighthub.smartbear.com"
+func TestAWSEndpoints(t *testing.T) {
+	hubNotify := "https://notify.bugsnag.smartbear.com"
+	hubSession := "https://sessions.bugsnag.smartbear.com"
 	customNofify := "https://custom.notify.com/"
 	customSessions := "https://custom.sessions.com/"
 	hubApiKey := "00000abcdef0123456789abcdef012345"
@@ -457,7 +457,7 @@ func TestInsightHubEndpoints(t *testing.T) {
 		}, logger
 	}
 
-	t.Run("Should use InsightHub endpoints if API key has prefix", func(st *testing.T) {
+	t.Run("Should use AWS endpoints if API key has prefix", func(st *testing.T) {
 		c, _ := setUp()
 		c.update(&Configuration{
 			APIKey: hubApiKey,
@@ -471,7 +471,7 @@ func TestInsightHubEndpoints(t *testing.T) {
 		}
 	})
 
-	t.Run("Should prefer custom endpoints over InsightHub endpoints", func(st *testing.T) {
+	t.Run("Should prefer custom endpoints over AWS endpoints", func(st *testing.T) {
 		c, _ := setUp()
 		c.update(&Configuration{
 			APIKey: hubApiKey,
@@ -488,7 +488,7 @@ func TestInsightHubEndpoints(t *testing.T) {
 		}
 	})
 
-	t.Run("With InsightHub API key and only custom notify endpoint, sessions should be empty", func(st *testing.T) {
+	t.Run("With AWS API key and only custom notify endpoint, sessions should be empty", func(st *testing.T) {
 		c, _ := setUp()
 		c.update(&Configuration{
 			APIKey: hubApiKey,
@@ -504,7 +504,7 @@ func TestInsightHubEndpoints(t *testing.T) {
 		}
 	})
 
-	t.Run("With InsightHub API key and only custom session endpoint, panic should be thrown", func(st *testing.T) {
+	t.Run("With AWS API key and only custom session endpoint, panic should be thrown", func(st *testing.T) {
 		c, _ := setUp()
 		defer func() {
 			if err := recover(); err != nil {

--- a/v2/configuration_test.go
+++ b/v2/configuration_test.go
@@ -443,12 +443,12 @@ func TestIsAutoCaptureSessions(t *testing.T) {
 	}
 }
 
-func TestAWSEndpoints(t *testing.T) {
-	hubNotify := "https://notify.bugsnag.smartbear.com"
-	hubSession := "https://sessions.bugsnag.smartbear.com"
-	customNofify := "https://custom.notify.com/"
+func TestSecondaryEndpoints(t *testing.T) {
+	secondaryNotify := "https://notify.bugsnag.smartbear.com"
+	secondarySession := "https://sessions.bugsnag.smartbear.com"
+	customNotify := "https://custom.notify.com/"
 	customSessions := "https://custom.sessions.com/"
-	hubApiKey := "00000abcdef0123456789abcdef012345"
+	secondaryApiKey := "00000abcdef0123456789abcdef012345"
 
 	setUp := func() (*Configuration, *CustomTestLogger) {
 		logger := &CustomTestLogger{}
@@ -457,30 +457,30 @@ func TestAWSEndpoints(t *testing.T) {
 		}, logger
 	}
 
-	t.Run("Should use AWS endpoints if API key has prefix", func(st *testing.T) {
+	t.Run("Should use secondary endpoints if API key has prefix", func(st *testing.T) {
 		c, _ := setUp()
 		c.update(&Configuration{
-			APIKey: hubApiKey,
+			APIKey: secondaryApiKey,
 		})
 
-		if got, exp := c.Endpoints.Notify, hubNotify; got != exp {
+		if got, exp := c.Endpoints.Notify, secondaryNotify; got != exp {
 			st.Errorf("Expected notify endpoint to be '%s' but was '%s'", exp, got)
 		}
-		if got, exp := c.Endpoints.Sessions, hubSession; got != exp {
+		if got, exp := c.Endpoints.Sessions, secondarySession; got != exp {
 			st.Errorf("Expected sessions endpoint to be '%s' but was '%s'", exp, got)
 		}
 	})
 
-	t.Run("Should prefer custom endpoints over AWS endpoints", func(st *testing.T) {
+	t.Run("Should prefer custom endpoints over secondary endpoints", func(st *testing.T) {
 		c, _ := setUp()
 		c.update(&Configuration{
-			APIKey: hubApiKey,
+			APIKey: secondaryApiKey,
 			Endpoints: Endpoints{
-				Notify:   customNofify,
+				Notify:   customNotify,
 				Sessions: customSessions,
 			},
 		})
-		if got, exp := c.Endpoints.Notify, customNofify; got != exp {
+		if got, exp := c.Endpoints.Notify, customNotify; got != exp {
 			st.Errorf("Expected notify endpoint to be '%s' but was '%s'", exp, got)
 		}
 		if got, exp := c.Endpoints.Sessions, customSessions; got != exp {
@@ -488,15 +488,15 @@ func TestAWSEndpoints(t *testing.T) {
 		}
 	})
 
-	t.Run("With AWS API key and only custom notify endpoint, sessions should be empty", func(st *testing.T) {
+	t.Run("With secondary endpoint API key and only custom notify endpoint, sessions should be empty", func(st *testing.T) {
 		c, _ := setUp()
 		c.update(&Configuration{
-			APIKey: hubApiKey,
+			APIKey: secondaryApiKey,
 			Endpoints: Endpoints{
-				Notify: customNofify,
+				Notify: customNotify,
 			},
 		})
-		if got, exp := c.Endpoints.Notify, customNofify; got != exp {
+		if got, exp := c.Endpoints.Notify, customNotify; got != exp {
 			st.Errorf("Expected notify endpoint to be '%s' but was '%s'", exp, got)
 		}
 		if got, exp := c.Endpoints.Sessions, ""; got != exp {
@@ -504,7 +504,7 @@ func TestAWSEndpoints(t *testing.T) {
 		}
 	})
 
-	t.Run("With AWS API key and only custom session endpoint, panic should be thrown", func(st *testing.T) {
+	t.Run("With secondary API key and only custom session endpoint, panic should be thrown", func(st *testing.T) {
 		c, _ := setUp()
 		defer func() {
 			if err := recover(); err != nil {
@@ -520,7 +520,7 @@ func TestAWSEndpoints(t *testing.T) {
 		}()
 
 		c.update(&Configuration{
-			APIKey: hubApiKey,
+			APIKey: secondaryApiKey,
 			Endpoints: Endpoints{
 				Sessions: customSessions,
 			},


### PR DESCRIPTION
## Goal
Rename alternative endpoints urls.

## Changeset
Renamed notify/session endpoints depending on the context.
Edited contributing guide to reflect current rules.
