### PR TITLE
Update version to 2.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.6.2 (2025-09-02)
+
+### Bug fixes
+
+* Set endpoint with default value only if API key is not nil [#267](https://github.com/bugsnag/bugsnag-go/pull/267)
+
 ## 2.6.1 (2025-07-22)
 
 ### Bug fixes

--- a/v2/bugsnag.go
+++ b/v2/bugsnag.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Version defines the version of this Bugsnag notifier
-const Version = "2.6.1"
+const Version = "2.6.2"
 
 var panicHandlerOnce sync.Once
 var sessionTrackerOnce sync.Once


### PR DESCRIPTION
## 2.6.2 (2025-09-02)

### Bug fixes

* Set endpoint with default value only if API key is not nil [#267](https://github.com/bugsnag/bugsnag-go/pull/267)