### PR TITLE
Fix issue where setting Synchronous config per notify did not work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD ()
+
+### Bug fixes
+
+* Fix issue where setting Synchronous config per notify did not work [#272](https://github.com/bugsnag/bugsnag-go/pull/272)
+
 ## 2.6.2 (2025-09-02)
 
 ### Bug fixes

--- a/v2/bugsnag_test.go
+++ b/v2/bugsnag_test.go
@@ -184,6 +184,50 @@ func TestNotifySyncThenAsync(t *testing.T) {
 	}
 }
 
+func TestNotifySyncJustForOne(t *testing.T) {
+	ts, _ := setup()
+	defer ts.Close()
+
+	eventserver, _ := setup()
+	defer eventserver.Close()
+
+	// Save old config to restore later after the tests
+	oldConfig := Config.clone()
+
+	_, cancel := setupState()
+	defer cancel()
+
+	pub := new(testPublisher)
+	publisher = pub
+	defer func() { publisher = newPublisher() }()
+
+	t.Run("global async but individual sync", func(st *testing.T) {
+		config := generateSampleConfig(eventserver.URL, context.Background())
+		Config.update(&config)
+		Config.Synchronous = false
+
+		Notify(fmt.Errorf("oopsie"), Configuration{Synchronous: true})
+
+		if pub.sync != true {
+			t.Error("Expected per event configuration to be set to Synchronous")
+		}
+	})
+
+	t.Run("global sync but individual async", func(st *testing.T) {
+		config := generateSampleConfig(eventserver.URL, context.Background())
+		Config.update(&config)
+		Config.Synchronous = true
+
+		Notify(fmt.Errorf("oopsie"), Configuration{Synchronous: false})
+
+		if pub.sync != false {
+			t.Error("Expected per event configuration to be set to Asynchronous")
+		}
+	})
+
+	Config = *oldConfig
+}
+
 func TestHandlerFunc(t *testing.T) {
 	eventserver, reports := setup()
 	defer eventserver.Close()

--- a/v2/notifier.go
+++ b/v2/notifier.go
@@ -53,7 +53,19 @@ func (notifier *Notifier) Notify(err error, rawData ...interface{}) (e error) {
 	// Stripping one stackframe to not include this function in the stacktrace
 	// for a manual notification.
 	skipFrames := 1
-	return notifier.NotifySync(errors.New(err, skipFrames), notifier.Config.Synchronous, rawData...)
+
+	// in case user passed a Synchronous Configuration value in rawData
+	// write it to sync parameter as it's processed as the last object in newEvent
+	// that way it's a preferred value over global configuration
+	sync := notifier.Config.Synchronous
+	for _, datum := range rawData {
+		switch datum := datum.(type) {
+		case Configuration:
+			sync = datum.Synchronous
+		}
+	}
+
+	return notifier.NotifySync(errors.New(err, skipFrames), sync, rawData...)
 }
 
 // NotifySync sends an error to Bugsnag. A boolean parameter specifies whether


### PR DESCRIPTION
## Goal
While calling Notify with per-error Configuration the Synchronous field in said configuration was ignored.

## Changeset
In Notify added a check - if additional Configuration is passed, prefer it over the global config field.

## Testing
New unit tests.