### PR TITLE
Add ability to run e2e tests in scaler environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
-# Ignore maze runner generated files
+# Maze Runner
 maze_output
 vendor
-
-# ignore the gemfile to prevent testing against stale versions
 Gemfile.lock
+maze-runner.log
+
+# Zscaler certificates
+.zscaler-root-ca.pem
+
+# IDE files
+.idea
+bugsnag-go.iml

--- a/LOCAL_TESTING.md
+++ b/LOCAL_TESTING.md
@@ -13,17 +13,25 @@ ASDF_GOLANG_OVERWRITE_ARCH=amd64 asdf install golang 1.11.13
 malformed DWARF TagVariable entry
 ```
 
-## Local testing with maze runner
+## Zscaler environments
 
-* Maze runner tests require
-  * Specyfing `GO_VERSION` env variable to set a golang version for docker container.
+If running e2e tests in an environment with Zscaler, first run copy the root certificate into place using:
+```
+ruby scripts/zscaler_setup.rb
+```
+The script excepts the certificate to be located at `./.zscaler-root-ca.pem`.
+
+## Local testing with Maze Runner
+
+* Maze Runner tests require
+  * Specifying `GO_VERSION` env variable to set a golang version for docker container.
   * Ruby 2.7.
   * Running docker.
 
 * Commands to run tests
 
 ```
-	bundle install
-	bundle exec maze-runner
-  bundle exec maze-runner -c features/<chosen_feature>
+bundle install
+bundle exec maze-runner
+bundle exec maze-runner -c features/<chosen_feature>
 ```

--- a/features/fixtures/app/Dockerfile
+++ b/features/fixtures/app/Dockerfile
@@ -1,6 +1,26 @@
 ARG GO_VERSION
 FROM golang:${GO_VERSION}-alpine
 
+# Only applicable to development environments running Zscaler
+# These Docker commands are ugly but the approach being used across SB
+COPY .zscaler-root-ca.pem /tmp/zscaler-root-ca.crt
+RUN set -eux; \
+    if [ -f /etc/ssl/cert.pem ]; then \
+        cat /tmp/zscaler-root-ca.crt >> /etc/ssl/cert.pem; \
+    elif [ -f /etc/ssl/certs/ca-certificates.crt ]; then \
+        cat /tmp/zscaler-root-ca.crt >> /etc/ssl/certs/ca-certificates.crt; \
+    else \
+        mkdir -p /etc/ssl/certs; \
+        cp /tmp/zscaler-root-ca.crt /etc/ssl/certs/ca-certificates.crt; \
+        ln -sf /etc/ssl/certs/ca-certificates.crt /etc/ssl/cert.pem; \
+    fi; \
+    apk add --no-cache ca-certificates; \
+    mkdir -p /usr/local/share/ca-certificates; \
+    cp /tmp/zscaler-root-ca.crt /usr/local/share/ca-certificates/zscaler-root-ca.crt; \
+    chmod 644 /usr/local/share/ca-certificates/zscaler-root-ca.crt; \
+    update-ca-certificates; \
+    rm -f /tmp/zscaler-root-ca.crt
+
 RUN apk update && apk upgrade && apk add git bash build-base
 
 ENV GOPATH /app

--- a/features/fixtures/app/Dockerfile
+++ b/features/fixtures/app/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:${GO_VERSION}-alpine
 
 # Only applicable to development environments running Zscaler
 # These Docker commands are ugly but the approach being used across SB
-COPY .zscaler-root-ca.pem /tmp/zscaler-root-ca.crt
+COPY .zscaler-root-ca.pem* /tmp/zscaler-root-ca.crt
 RUN set -eux; \
     if [ -f /etc/ssl/cert.pem ]; then \
         cat /tmp/zscaler-root-ca.crt >> /etc/ssl/cert.pem; \

--- a/features/fixtures/app/Dockerfile
+++ b/features/fixtures/app/Dockerfile
@@ -4,22 +4,27 @@ FROM golang:${GO_VERSION}-alpine
 # Only applicable to development environments running Zscaler
 # These Docker commands are ugly but the approach being used across SB
 COPY .zscaler-root-ca.pem* /tmp/zscaler-root-ca.crt
-RUN set -eux; \
-    if [ -f /etc/ssl/cert.pem ]; then \
-        cat /tmp/zscaler-root-ca.crt >> /etc/ssl/cert.pem; \
-    elif [ -f /etc/ssl/certs/ca-certificates.crt ]; then \
-        cat /tmp/zscaler-root-ca.crt >> /etc/ssl/certs/ca-certificates.crt; \
+RUN if [ -f /tmp/zscaler-root-ca.crt ]; then \
+        echo "Zscaler root CA certificate found, adding to trusted certificates"; \
+        set -eux; \
+        if [ -f /etc/ssl/cert.pem ]; then \
+            cat /tmp/zscaler-root-ca.crt >> /etc/ssl/cert.pem; \
+        elif [ -f /etc/ssl/certs/ca-certificates.crt ]; then \
+            cat /tmp/zscaler-root-ca.crt >> /etc/ssl/certs/ca-certificates.crt; \
+        else \
+            mkdir -p /etc/ssl/certs; \
+            cp /tmp/zscaler-root-ca.crt /etc/ssl/certs/ca-certificates.crt; \
+            ln -sf /etc/ssl/certs/ca-certificates.crt /etc/ssl/cert.pem; \
+        fi; \
+        apk add --no-cache ca-certificates; \
+        mkdir -p /usr/local/share/ca-certificates; \
+        cp /tmp/zscaler-root-ca.crt /usr/local/share/ca-certificates/zscaler-root-ca.crt; \
+        chmod 644 /usr/local/share/ca-certificates/zscaler-root-ca.crt; \
+        update-ca-certificates; \
+        rm -f /tmp/zscaler-root-ca.crt \
     else \
-        mkdir -p /etc/ssl/certs; \
-        cp /tmp/zscaler-root-ca.crt /etc/ssl/certs/ca-certificates.crt; \
-        ln -sf /etc/ssl/certs/ca-certificates.crt /etc/ssl/cert.pem; \
-    fi; \
-    apk add --no-cache ca-certificates; \
-    mkdir -p /usr/local/share/ca-certificates; \
-    cp /tmp/zscaler-root-ca.crt /usr/local/share/ca-certificates/zscaler-root-ca.crt; \
-    chmod 644 /usr/local/share/ca-certificates/zscaler-root-ca.crt; \
-    update-ca-certificates; \
-    rm -f /tmp/zscaler-root-ca.crt
+        echo "No Zscaler root CA certificate found, skipping addition to trusted certificates"; \
+    fi;
 
 RUN apk update && apk upgrade && apk add git bash build-base
 

--- a/scripts/zscaler-setup.rb
+++ b/scripts/zscaler-setup.rb
@@ -1,4 +1,4 @@
-# Setup script for anyone working in a scaler environment.  This script assumes that the root certificate is present
+# Setup script for anyone working in a Zscaler environment.  This script assumes that the root certificate is present
 # at ~/.zscaler-root-ca.pem and copies it into place in each of the test fixture so that the Docker builds can install
 # it into the built images.  This is not need on CI or in other non-Zscaler environments.
 

--- a/scripts/zscaler-setup.rb
+++ b/scripts/zscaler-setup.rb
@@ -10,7 +10,6 @@ unless File.exist?(certificate_path)
   abort("Zscaler root certificate not found at #{certificate_path}")
 end
 
-
 folder = '.'
 puts "Copying Zscaler root certificate to #{folder}"
 FileUtils.cp(certificate_path, folder)

--- a/scripts/zscaler-setup.rb
+++ b/scripts/zscaler-setup.rb
@@ -1,0 +1,16 @@
+# Setup script for anyone working in a scaler environment.  This script assumes that the root certificate is present
+# at ~/.zscaler-root-ca.pem and copies it into place in each of the test fixture so that the Docker builds can install
+# it into the built images.  This is not need on CI or in other non-Zscaler environments.
+
+require 'fileutils'
+
+# Create an array of all folders under features/fixtures
+certificate_path = File.expand_path("~/.zscaler-root-ca.pem")
+unless File.exist?(certificate_path)
+  abort("Zscaler root certificate not found at #{certificate_path}")
+end
+
+
+folder = '.'
+puts "Copying Zscaler root certificate to #{folder}"
+FileUtils.cp(certificate_path, folder)


### PR DESCRIPTION
## Goal

Enable the running of e2e tests in Zscaler environments.

## Design

Dockerfile now inserts the Zscaler root certificate into the image's trust store.  The Dockerfile line are unpleasant, but they are taken verbatim from the approach used across SmartBear.

## Testing

Successfully ran a feature file locally.